### PR TITLE
Update text that appears in Google results for "bitclout" 

### DIFF
--- a/src/app/landing-page/landing-page.component.html
+++ b/src/app/landing-page/landing-page.component.html
@@ -154,10 +154,9 @@
     <div class="col-lg-8 col-md-9 col-sm-12 text-center landing__prop">
       <h3 class="landing__prop-header">Decentralized like Bitcoin</h3>
       <p class="landing__prop-desc">
-        <b>BitClout is not a company.</b>
-        It's an open-source blockchain like Bitcoin.
+        <b>BitClout is an open-source blockchain reimagining the social network.</b>
         <br class="d-none d-md-block" />
-        You can own a piece by buying the BitClout coin $CLOUT.
+        Own a piece by buying the BitClout coin $CLOUT.
         <br />
         <br />
         <a href="https://docs.bitclout.com/the-vision" target="_blank">Learn More</a>


### PR DESCRIPTION
The current text says what Bitclout isn't but not what it _is_

![image](https://user-images.githubusercontent.com/14790281/125347127-66953080-e30f-11eb-81e2-cd7d8e06bfa4.png)
