### PR TITLE
fix (identity service): Update shape of outbound requests property

### DIFF
--- a/src/app/identity.service.ts
+++ b/src/app/identity.service.ts
@@ -11,7 +11,7 @@ export class IdentityService {
   private pendingRequests = [];
 
   // All outbound request promises we still need to resolve
-  private outboundRequests = {};
+  private outboundRequests: {[key: string]: Subject<unknown>} = {};
 
   // The currently active identity window
   private identityWindow;


### PR DESCRIPTION
In  Angular strict mode, `private outboundRequests = {}` throws errors during compilation:

```
  No index signature with a parameter of type 'string' was found on type '{}'.
```
Making the expected shape of the object explicit fixes the error. This service requires other updates as well to be compliant with strict mode, but this one is a bit tricky.