### PR TITLE
fix-close-left-bar-on-start-tutorial

### DIFF
--- a/src/app/left-bar/left-bar.component.ts
+++ b/src/app/left-bar/left-bar.component.ts
@@ -64,6 +64,10 @@ export class LeftBarComponent {
     if (this.inTutorial) {
       return;
     }
+    
+    // close sidebar in case of mobile
+    this.globalVars.isLeftBarMobileOpen = false;
+
     // If the user hes less than 1/100th of a clout they need more clout for the tutorial.
     if (this.globalVars.loggedInUser?.BalanceNanos < 1e7) {
       SwalHelper.fire({


### PR DESCRIPTION
When opening tutorial on iOS the left-sidebar remains open, causing part of screen to be hidden when starting.

![telegram-cloud-photo-size-1-5003747117746989402-y](https://user-images.githubusercontent.com/69529928/131707927-481ed31c-d1df-4d2f-b69d-6cdf3d53908b.jpg)

This fix closes the left-sidebar on mobile.