### PR TITLE
Add min bid to single nfts if greater then 0

### DIFF
--- a/src/app/feed/feed-post/feed-post.component.html
+++ b/src/app/feed/feed-post/feed-post.component.html
@@ -490,6 +490,9 @@
         <div *ngIf="nftLastAcceptedBidAmountNanos">
           <b>Last price: {{ globalVars.nanosToBitClout(nftLastAcceptedBidAmountNanos) }} $CLOUT</b>
         </div>
+        <div *ngIf="nftMinBidAmountNanos">
+          <b>Min bid: {{ globalVars.nanosToBitClout(nftMinBidAmountNanos) }} $CLOUT</b>
+        </div>
       </div>
       <button
         class="btn btn-primary font-weight-bold br-8px fs-13px"

--- a/src/app/feed/feed-post/feed-post.component.ts
+++ b/src/app/feed/feed-post/feed-post.component.ts
@@ -96,6 +96,7 @@ export class FeedPostComponent implements OnInit {
   @Input() nftCollectionLowBid = 0;
   @Input() isForSaleOnly: boolean = false;
   nftLastAcceptedBidAmountNanos: number;
+  nftMinBidAmountNanos: number;
 
   @Input() showNFTDetails = false;
   @Input() showExpandedNFTDetails = false;
@@ -197,6 +198,9 @@ export class FeedPostComponent implements OnInit {
         this.lowBid = _.minBy(this.availableSerialNumbers, "HighestBidAmountNanos")?.HighestBidAmountNanos || 0;
         if (this.nftEntryResponses.length === 1) {
           this.nftLastAcceptedBidAmountNanos = this.nftEntryResponses[0].LastAcceptedBidAmountNanos;
+          if (this.nftEntryResponses[0].MinBidAmountNanos>0) {
+            this.nftMinBidAmountNanos = this.nftEntryResponses[0].MinBidAmountNanos;
+          }
         }
       });
   }

--- a/src/app/feed/feed-post/feed-post.component.ts
+++ b/src/app/feed/feed-post/feed-post.component.ts
@@ -198,7 +198,7 @@ export class FeedPostComponent implements OnInit {
         this.lowBid = _.minBy(this.availableSerialNumbers, "HighestBidAmountNanos")?.HighestBidAmountNanos || 0;
         if (this.nftEntryResponses.length === 1) {
           this.nftLastAcceptedBidAmountNanos = this.nftEntryResponses[0].LastAcceptedBidAmountNanos;
-          if (this.nftEntryResponses[0].MinBidAmountNanos>0) {
+          if (this.nftEntryResponses[0].MinBidAmountNanos > 0) {
             this.nftMinBidAmountNanos = this.nftEntryResponses[0].MinBidAmountNanos;
           }
         }


### PR DESCRIPTION
Too often get caught out when I see low last bid, click on make bid, and turns out min bid is way higher.

So added to @iPaulPro recent change to also show min bid if its greater than 0.

![20210918-GVkvgdxn](https://user-images.githubusercontent.com/69529928/133894664-dedd6b23-d8f7-413e-9c18-ccc5cb5b7056.png)
