### PR TITLE
fix safari 15 tab bar background and over-scroll area light & dark mode.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,8 @@
     <meta name="referrer" content="no-referrer" />
     <title>Welcome to DeSo</title>
     <meta name="description" content="DeSo is a platform owned by its users. Bitcoin is decentralizing money, DeSo is decentralizing social media." />
-    <meta name="theme-color" content="#7289DA" />
+    <meta name="theme-color" content="#eeeeee" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#121212" media="(prefers-color-scheme: dark)">
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:image" content="https://bitclout.com/assets/img/camelcase_logo_og.jpg" />
     <meta property="og:title" content="Welcome to DeSo" />


### PR DESCRIPTION
Safari v15 that just rolled out the other day uses meta tag theme-colour to set colour of tab bar background and over-scroll area in macOS and iPadOS, and the status bar in iOS.

https://developer.apple.com/documentation/safari-release-notes/safari-15-beta-release-notes

![20210922-55UsRtfW](https://user-images.githubusercontent.com/69529928/134378193-3e2a087e-4706-4cff-998f-e6a208e4ec84.png)

![20210922-wpXhKquK](https://user-images.githubusercontent.com/69529928/134378206-fa5d9384-a3df-42a2-8646-78e23b01ef64.png)

This change sets it to white for light mode, and very dark gray for dark mode.


After fix looks like this
![20210922-J6BKAFRv](https://user-images.githubusercontent.com/69529928/134379770-725f87a4-d9c8-4de7-8b81-e033dec53059.png)
![20210922-7vGmi2D0](https://user-images.githubusercontent.com/69529928/134379784-667ab384-bbbf-4bac-aa25-31927be2cea9.png)


