### PR TITLE
Click-here Pointer in Tutorial

### DIFF
--- a/src/app/wallet/wallet.component.html
+++ b/src/app/wallet/wallet.component.html
@@ -252,7 +252,7 @@
     </div>
   </div>
 
-  <div *ngIf="inTutorial" class="row no-gutters fs-15px fc-default mt-5px mb-5px ml-10px mr-10px p-5px">
+  <div *ngIf="inTutorial && tutorialStatus === TutorialStatus.INVEST_OTHERS_BUY" class="row no-gutters fs-15px fc-default mt-5px mb-5px ml-10px mr-10px p-5px">
     <div class="col"></div>
     <div class="col-lg-1 col-2 d-flex flex-column align-items-center justify-content-center">
       <i class="fas fa-hand-point-up fc-red fa-lg mb-5px"></i>


### PR DESCRIPTION
The Click-here Pointer is shown in 

1. Step 4 after user buys their own coin - 
2. At the end of Step 2 even after user sells others coin

Hence the proposed change after which the click here pointer will be shown only in the beginning of Step 2 for the user to sell others coin

Reference - @tijno quick PR Challenge #1 - https://bitclout.com/posts/c055d0046ef8f02ca129b8fd7137c603a858564a657507cc7d1e331954e7dead?feedTab=Following