### PR TITLE
Compute ETH values based on wei

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -185,7 +185,7 @@ export class AppComponent implements OnInit {
         this.globalVars.createProfileFeeNanos = res.CreateProfileFeeNanos;
         this.globalVars.isCompProfileCreation = this.globalVars.showPhoneNumberVerification && res.CompProfileCreation;
         this.globalVars.buyETHAddress = res.BuyETHAddress;
-      
+
         this.globalVars.transactionFeeMap = res.TransactionFeeMap;
 
         // Calculate max fee for display in frontend
@@ -200,10 +200,10 @@ export class AppComponent implements OnInit {
             return { "txnType": txnType, "fees": sumOfFees }
           }
         }).sort( (a,b)=>b.fees-a.fees);
-        
+
         //Get the max of all fees
         this.globalVars.transactionFeeMax = Math.max( ...simpleFeeMap.map(k=>k.fees) );
-        
+
         //Prepare text detailed info of fees and join with newlines
         this.globalVars.transactionFeeInfo = simpleFeeMap.map(k=>`${k.txnType}: ${this.globalVars.nanosToUSD(k.fees,4)}`).join("\n");
       });

--- a/src/app/buy-deso-page/buy-deso-eth/buy-deso-eth.component.html
+++ b/src/app/buy-deso-page/buy-deso-eth/buy-deso-eth.component.html
@@ -34,7 +34,7 @@
       <span>
         Minimum deposit is currently
         <b>
-          {{ (ethFeeEstimate() * 2).toFixed(4) }} ETH
+          {{ (ethFeeEstimate * 2).toFixed(4) }} ETH
         </b>
         <i
           (click)="tooltip3.toggle()"
@@ -87,13 +87,13 @@
       >
         <div class="pl-10px">
           <div *ngIf="!loadingBalance">
-            {{ ethBalance().toFixed(8) }} ETH
+            {{ ethBalance.toFixed(8) }} ETH
 
             <span class="text-grey7">
               ≈
               {{
                 globalVars.formatUSD(
-                  (ethBalance() * globalVars.usdPerETHExchangeRate),
+                  (ethBalance * globalVars.usdPerETHExchangeRate),
                   2
                 )
               }}
@@ -197,10 +197,10 @@
 
       <div class="mt-1 w-100 fs-15px">
         <div *ngIf="error == null || error === ''">
-          {{ ethFeeEstimate().toFixed(8) }}
+          {{ ethFeeEstimate.toFixed(8) }}
           ETH ≈
           {{
-            globalVars.formatUSD(ethFeeEstimate() * globalVars.usdPerETHExchangeRate, 2)
+            globalVars.formatUSD(ethFeeEstimate * globalVars.usdPerETHExchangeRate, 2)
           }}
           USD
         </div>

--- a/src/app/buy-deso-page/buy-deso-eth/buy-deso-eth.component.html
+++ b/src/app/buy-deso-page/buy-deso-eth/buy-deso-eth.component.html
@@ -153,6 +153,7 @@
         class="form-control w-50 fs-15px lh-15px"
         style="text-align: right"
         placeholder="0"
+        type="number"
         [(ngModel)]="desoToBuy"
         (ngModelChange)="updateDESOToBuy($event)"
       />

--- a/src/app/buy-deso-page/buy-deso-eth/buy-deso-eth.component.html
+++ b/src/app/buy-deso-page/buy-deso-eth/buy-deso-eth.component.html
@@ -34,7 +34,7 @@
       <span>
         Minimum deposit is currently
         <b>
-          {{ (ethFeeEstimate * 2).toFixed(4) }} ETH
+          {{ (ethFeeEstimate() * 2).toFixed(4) }} ETH
         </b>
         <i
           (click)="tooltip3.toggle()"
@@ -87,13 +87,13 @@
       >
         <div class="pl-10px">
           <div *ngIf="!loadingBalance">
-            {{ ethBalance.toFixed(8) }} ETH
+            {{ ethBalance().toFixed(8) }} ETH
 
             <span class="text-grey7">
               ≈
               {{
                 globalVars.formatUSD(
-                  (ethBalance * globalVars.usdPerETHExchangeRate),
+                  (ethBalance() * globalVars.usdPerETHExchangeRate),
                   2
                 )
               }}
@@ -178,6 +178,7 @@
         placeholder="0"
         [(ngModel)]="ethToExchange"
         (ngModelChange)="updateETHToExchange($event)"
+        type="number"
       />
       <div class="ml-2 w-50 fs-15px">ETH</div>
     </div>
@@ -196,10 +197,10 @@
 
       <div class="mt-1 w-100 fs-15px">
         <div *ngIf="error == null || error === ''">
-          {{ ethFeeEstimate.toFixed(8) }}
+          {{ ethFeeEstimate().toFixed(8) }}
           ETH ≈
           {{
-            globalVars.formatUSD(ethFeeEstimate * globalVars.usdPerETHExchangeRate, 2)
+            globalVars.formatUSD(ethFeeEstimate() * globalVars.usdPerETHExchangeRate, 2)
           }}
           USD
         </div>

--- a/src/app/buy-deso-page/buy-deso-eth/buy-deso-eth.component.ts
+++ b/src/app/buy-deso-page/buy-deso-eth/buy-deso-eth.component.ts
@@ -405,7 +405,7 @@ export class BuyDeSoEthComponent implements OnInit {
 
   getValue(totalFees: BN): Hex {
     // Make sure that value + actual fees does not exceed the current balance. If it does, subtract the remainder from value.
-    let value = this.weiToExchange.sub(this.weiFeeEstimate);
+    let value = this.weiToExchange.sub(totalFees);
     let remainder = totalFees.add(value).sub(this.weiBalance);
     if (remainder.gt(0)) {
       value = value.sub(remainder);

--- a/src/app/buy-deso-page/buy-deso-eth/buy-deso-eth.component.ts
+++ b/src/app/buy-deso-page/buy-deso-eth/buy-deso-eth.component.ts
@@ -494,7 +494,7 @@ export class BuyDeSoEthComponent implements OnInit {
     if (newVal == null || newVal === "") {
       this.desoToBuy = 0;
       this.ethToExchange = 0;
-      this.weiToExchange = 0;
+      this.weiToExchange = new BN(0);
     } else {
       // Convert the string value to a number
       this.weiToExchange = this.toWeiBN(newVal);

--- a/src/app/buy-deso-page/buy-deso-eth/buy-deso-eth.component.ts
+++ b/src/app/buy-deso-page/buy-deso-eth/buy-deso-eth.component.ts
@@ -164,13 +164,11 @@ export class BuyDeSoEthComponent implements OnInit {
       return;
     }
 
-    // if (Number(this.ethToExchange) > this.ethBalance) {
     if (this.weiToExchange.gt(this.weiBalance)) {
       this.globalVars._alertError(Messages.INSUFFICIENT_BALANCE);
       return;
     }
 
-    // if (Number(this.ethToExchange) < this.ethFeeEstimate) {
     if (this.weiToExchange.lt(this.weiFeeEstimate)) {
       this.globalVars._alertError(Messages.INSUFFICIENT_FEES);
       return;
@@ -226,7 +224,7 @@ export class BuyDeSoEthComponent implements OnInit {
             // Reset all the form fields
             this.error = "";
             this.desoToBuy = 0;
-            // this.ethToExchange = "0";
+            this.ethToExchange = 0;
             this.weiToExchange = new BN(0);
             // This will update the balance and a bunch of other things.
             this.globalVars.updateEverything(
@@ -410,7 +408,7 @@ export class BuyDeSoEthComponent implements OnInit {
     let value = this.weiToExchange.sub(this.weiFeeEstimate);
     let remainder = totalFees.add(value).sub(this.weiBalance);
     if (remainder.gt(0)) {
-      value = value - remainder;
+      value = value.sub(remainder);
     }
     return toHex(value);
   }

--- a/src/app/buy-deso-page/buy-deso-eth/buy-deso-eth.component.ts
+++ b/src/app/buy-deso-page/buy-deso-eth/buy-deso-eth.component.ts
@@ -56,16 +56,19 @@ export class BuyDeSoEthComponent implements OnInit {
   @Input() parentComponent: BuyDeSoComponent;
 
   // Current balance in ETH
-  // ethBalance = 0;
+  // Eth balance is only for display purposes.
+  ethBalance = 0;
   weiBalance: BN = new BN(0);
   loadingBalance = false;
   loadingFee = false;
 
   // Network fees in ETH (with sane default)
-  // ethFeeEstimate = 0.002;
+  // ETH fee estimate is only for display purposes.
+  ethFeeEstimate = 0.002;
   weiFeeEstimate: BN = new BN(0);
 
   // ETH to exchange (not including fees)
+  // Eth To Exchange is only for display purposes.
   ethToExchange: number = 0;
   weiToExchange: BN = new BN(0);
 
@@ -404,7 +407,6 @@ export class BuyDeSoEthComponent implements OnInit {
 
   getValue(totalFees: BN): Hex {
     // Make sure that value + actual fees does not exceed the current balance. If it does, subtract the remainder from value.
-    // let value = Math.floor((this.ethToExchange - this.ethFeeEstimate) * 1e18);
     let value = this.weiToExchange.sub(this.weiFeeEstimate);
     let remainder = totalFees.add(value).sub(this.weiBalance);
     if (remainder.gt(0)) {
@@ -435,8 +437,7 @@ export class BuyDeSoEthComponent implements OnInit {
   clickMaxDESO() {
     this.getFees().then((res) => {
       this.weiFeeEstimate = res.totalFees;
-      // this.ethFeeEstimate = res.totalFees.toNumber();
-      // this.ethToExchange = this.ethBalance;
+      this.ethFeeEstimate = Number(fromWei(this.weiFeeEstimate));
       this.weiToExchange = this.weiBalance;
       this.updateETHToExchange(fromWei(this.weiToExchange));
     });
@@ -451,17 +452,12 @@ export class BuyDeSoEthComponent implements OnInit {
     return weiMinusFees.add(this.weiFeeEstimate);
   }
 
-  computeNanosToCreateGivenETHToBurn(ethToBurn: number): number {
-    return Number(this.computeNanosToCreateGivenWeiToBurn(this.toWeiBN(ethToBurn)));
-  }
-
-  computeNanosToCreateGivenWeiToBurn(weiToBurn: BN): BN {
+  computeNanosToCreateGivenWeiToBurn(weiToBurn: BN): number {
     let weiMinusFees = weiToBurn.sub(this.weiFeeEstimate);
-    debugger;
     if (weiMinusFees.ltn(0)) {
       return new BN(0);
     }
-    return Number(fromWei(weiMinusFees)) * this.getExchangeRateAfterFee();
+    return Number(fromWei(weiMinusFees)) * this.getExchangeRateAfterFee().toNumber();
   }
 
   getExchangeRateAfterFee(): BN {
@@ -501,21 +497,13 @@ export class BuyDeSoEthComponent implements OnInit {
     return 1 + this.globalVars.BuyDeSoFeeBasisPoints / (100 * 100);
   }
 
-  ethBalance(): number {
-    return Number(fromWei(this.weiBalance));
-  }
-
-  ethFeeEstimate(): number {
-    return Number(fromWei(this.weiFeeEstimate));
-  }
-
   refreshBalance() {
     if (!this.loadingBalance) {
       this.loadingBalance = true;
       this.getBalance(this.ethDepositAddress(), "latest")
         .then((res) => {
-          // this.ethBalance = parseFloat(fromWei(res.toString(), "ether"));
           this.weiBalance = toBN(res);
+          this.ethBalance = Number(fromWei(this.weiBalance));
         })
         .finally(() => {
           this.loadingBalance = false;
@@ -524,9 +512,8 @@ export class BuyDeSoEthComponent implements OnInit {
     if (!this.loadingFee) {
       this.loadingFee = true;
       this.getFees().then((res) => {
-        // this.ethFeeEstimate = this.fromWeiToEther(res.totalFees);
         this.weiFeeEstimate = res.totalFees;
-        // this.ethToExchange = this.ethFeeEstimate.toString();
+        this.ethFeeEstimate = Number(fromWei(this.weiFeeEstimate));
         this.weiToExchange = this.weiFeeEstimate;
         this.ethToExchange = Number(fromWei(this.weiFeeEstimate));
       });


### PR DESCRIPTION
There are rounding point errors when using Ether to compute the value in a transaction. Using BNs (big numbers) and making the computations in Wei as opposed to ETH should avoid these precision errors.