### PR TITLE
Add support for managing sign-up bonus configurations

### DIFF
--- a/src/app/admin/admin-jumio/admin-jumio-edit-country-sign-up-bonus/admin-jumio-edit-country-sign-up-bonus.component.html
+++ b/src/app/admin/admin-jumio/admin-jumio-edit-country-sign-up-bonus/admin-jumio-edit-country-sign-up-bonus.component.html
@@ -1,0 +1,60 @@
+<div app-theme class="p-15px">
+  <div class="d-flex flex-column">
+    <div>Update Sign-Up Bonus for {{ getCountryName() }} </div>
+    <div class="d-flex flex-column">
+      <div class="d-flex py-15px">
+        <label for="referral-amount-override-usd" class="cursor-pointer mb-0">Referral Amount Override ($USD): </label>
+        <input
+          id="referral-amount-override-usd"
+          [(ngModel)]="newReferralAmountOverrideUSD"
+          class="form-control w-100 fs-15px lh-15px"
+          placeholder="Enter an amount"
+          type="number"
+          min="0"
+          step="0.01"
+        />
+      </div>
+
+      <div class="d-flex py-15px">
+        <label for="allow-custom-referral-amount" class="cursor-pointer mb-0">Allow Custom Referral Amount: </label>
+        <input
+          id="allow-custom-referral-amount"
+          [(ngModel)]="newAllowCustomReferralAmount"
+          type="checkbox"/>
+      </div>
+
+      <div class="d-flex py-15px">
+        <label for="kickback-amount-override-usd" class="cursor-pointer mb-0">Kickback Amount Override ($USD): </label>
+        <input
+          id="kickback-amount-override-usd"
+          [(ngModel)]="newKickbackAmountOverrideUSD"
+          class="form-control w-100 fs-15px lh-15px"
+          placeholder="Enter an amount"
+          type="number"
+          min="0"
+          step="0.01"
+        />
+      </div>
+
+      <div class="d-flex py-15px">
+        <label for="allow-custom-kickback-amount" class="cursor-pointer mb-0">Allow Custom Kickback Amount: </label>
+        <input
+          id="allow-custom-kickback-amount"
+          [(ngModel)]="newAllowCustomKickbackAmount"
+          type="checkbox"/>
+      </div>
+    </div>
+    <div>
+      <button
+        class="btn btn-primary font-weight-bold ml-15px fs-14px br-12px"
+        style="height: 36px; width: 75px; line-height: 15px"
+        [ngClass]="{
+      disabled: updatingCountryLevelBonus,
+      'btn-loading': updatingCountryLevelBonus
+    }"
+        (click)="updateSignUpBonus()"
+      >Update</button>
+    </div>
+  </div>
+</div>
+

--- a/src/app/admin/admin-jumio/admin-jumio-edit-country-sign-up-bonus/admin-jumio-edit-country-sign-up-bonus.component.ts
+++ b/src/app/admin/admin-jumio/admin-jumio-edit-country-sign-up-bonus/admin-jumio-edit-country-sign-up-bonus.component.ts
@@ -1,0 +1,98 @@
+import { Component, Input, OnInit } from "@angular/core";
+import {
+  BackendApiService,
+  CountryCodeDetails,
+  CountryLevelSignUpBonus,
+  CountryLevelSignUpBonusResponse,
+} from "../../../backend-api.service";
+import { GlobalVarsService } from "../../../global-vars.service";
+import { BsModalRef } from "ngx-bootstrap/modal";
+import { BsModalService } from "ngx-bootstrap/modal";
+import { Router } from "@angular/router";
+
+@Component({
+  selector: "admin-jumio-edit-country-sign-up-bonus",
+  templateUrl: "./admin-jumio-edit-country-sign-up-bonus.component.html",
+})
+export class AdminJumioEditCountrySignUpBonusComponent implements OnInit {
+  @Input() countryLevelSignUpBonusResponse: CountryLevelSignUpBonusResponse;
+
+  newAllowCustomReferralAmount: boolean;
+  newAllowCustomKickbackAmount: boolean;
+  newReferralAmountOverrideUSD: number;
+  newKickbackAmountOverrideUSD: number;
+  updatingCountryLevelBonus: boolean = false;
+
+  constructor(
+    private globalVars: GlobalVarsService,
+    private backendApi: BackendApiService,
+    private modalService: BsModalService,
+    private router: Router,
+    public bsModalRef: BsModalRef
+  ) {}
+
+  ngOnInit(): void {
+    this.newAllowCustomKickbackAmount = this.getAllowCustomKickbackAmount();
+    this.newAllowCustomReferralAmount = this.getAllowCustomReferralAmount();
+    this.newReferralAmountOverrideUSD = this.getReferralAmountOverrideUSDCents() / 100;
+    this.newKickbackAmountOverrideUSD = this.getKickbackAmountOverrideUSDCents() / 100;
+  }
+
+  getCountryCodeDetails(): CountryCodeDetails {
+    return this.countryLevelSignUpBonusResponse.CountryCodeDetails;
+  }
+
+  getCountryLevelSignUpBonus(): CountryLevelSignUpBonus {
+    return this.countryLevelSignUpBonusResponse.CountryLevelSignUpBonus;
+  }
+
+  getCountryName(): string {
+    return this.getCountryCodeDetails().Name;
+  }
+
+  getCountryAlpha3(): string {
+    return this.getCountryCodeDetails().Alpha3;
+  }
+
+  getAllowCustomReferralAmount(): boolean {
+    return this.getCountryLevelSignUpBonus().AllowCustomReferralAmount;
+  }
+
+  getAllowCustomKickbackAmount(): boolean {
+    return this.getCountryLevelSignUpBonus().AllowCustomKickbackAmount;
+  }
+
+  getReferralAmountOverrideUSDCents(): number {
+    return this.getCountryLevelSignUpBonus().ReferralAmountOverrideUSDCents;
+  }
+
+  getKickbackAmountOverrideUSDCents(): number {
+    return this.getCountryLevelSignUpBonus().KickbackAmountOverrideUSDCents;
+  }
+
+  updateSignUpBonus() {
+    this.updatingCountryLevelBonus = true;
+    this.backendApi
+      .AdminUpdateJumioCountrySignUpBonus(
+        this.globalVars.localNode,
+        this.globalVars.loggedInUser?.PublicKeyBase58Check,
+        this.getCountryAlpha3(),
+        {
+          AllowCustomKickbackAmount: this.newAllowCustomKickbackAmount,
+          AllowCustomReferralAmount: this.newAllowCustomReferralAmount,
+          ReferralAmountOverrideUSDCents: Math.trunc(this.newReferralAmountOverrideUSD * 100),
+          KickbackAmountOverrideUSDCents: Math.trunc(this.newKickbackAmountOverrideUSD * 100),
+        }
+      )
+      .subscribe(
+        () => {
+          this.modalService.setDismissReason("sign-up-bonus-updated");
+          this.bsModalRef.hide();
+        },
+        (err) => {
+          console.error(err);
+        }
+      )
+      .add(() => (this.updatingCountryLevelBonus = false));
+  }
+}

--- a/src/app/admin/admin-jumio/admin-jumio.component.html
+++ b/src/app/admin/admin-jumio/admin-jumio.component.html
@@ -5,19 +5,19 @@
     (tabClick)="_handleTabClick($event)"></tab-selector>
   <div class="p-15px fs-15px" *ngIf="activeTab === AdminJumioComponent.GENERAL">
     <div class="fs-15px font-weight-bold mt-15px mb-15px px-15px">
-      Set Jumio Starter $DESO amount (in nanos):
+      Set Jumio Starter Amount in $USD:
       <div class="d-flex mt-5px">
         <input
-          [(ngModel)]="jumioDeSoNanos"
-          (keydown.enter)="updateJumioDeSoNanos()"
+          [(ngModel)]="jumioUSD"
+          (keydown.enter)="updateJumioUSDCents()"
           class="form-control w-100 fs-15px lh-15px"
           placeholder="Enter an amount"
           type="number"
         />
-        <button *ngIf="!updatingJumioDeSoNanos" (click)="updateJumioDeSoNanos()" class="btn btn-outline-primary fs-15px ml-5px">
+        <button *ngIf="!updatingJumioUSD" (click)="updateJumioUSDCents()" class="btn btn-outline-primary fs-15px ml-5px">
           Update
         </button>
-        <button *ngIf="updatingJumioDeSoNanos" class="btn btn-primary fs-15px ml-5px" disabled>
+        <button *ngIf="updatingJumioUSD" class="btn btn-primary fs-15px ml-5px" disabled>
           Working...
         </button>
       </div>
@@ -42,12 +42,24 @@
     <div class="fs-15px font-weight-bold mt-15px mb-15px px-15px">
       Execute Jumio Callback for Public Key or Username:
       <div class="d-flex mt-5px">
-        <input
-          [(ngModel)]="usernameToExecuteJumioCallback"
-          (keydown.enter)="_executeJumioCallback()"
-          class="form-control w-100 fs-15px lh-15px"
-          placeholder="Enter a username or public key."
-        />
+        <div class="d-flex flex-column">
+          <input
+            [(ngModel)]="usernameToExecuteJumioCallback"
+            (keydown.enter)="_executeJumioCallback()"
+            class="form-control w-100 fs-15px lh-15px"
+            placeholder="Enter a username or public key."
+          />
+          <select
+            name="country"
+            id="country-callback"
+            [(ngModel)]="jumioCallbackCountrySelected"
+            class="form-control selector mt-15px">
+            <option
+              *ngFor="let country of countryLevelSignUpBonuses | keyvalue"
+              [value]="country.value.CountryCodeDetails.Alpha3"
+              [selected]="jumioCallbackCountrySelected === country.value.CountryCodeDetails.Alpha3">{{ country.key }}</option>
+          </select>
+        </div>
         <button *ngIf="!executingJumioCallback" (click)="_executeJumioCallback()" class="btn btn-outline-primary fs-15px ml-5px">
           Execute
         </button>
@@ -69,12 +81,12 @@
         <div class="col-4 d-flex align-items-center">
           <i class="fa fa-pencil pr-5px"
              aria-hidden="true"
-             (click)="editCountry(signUpBonus.value.CountryCodeDetails.Alpha3)"
+             (click)="editCountry(signUpBonus.value.CountryCodeDetails.Name, $event)"
           ></i>
           <span>{{ signUpBonus.key }}</span>
         </div>
         <div class="col-2 d-flex">
-          {{ countryLevelSignUpBonuses[signUpBonus.key].CountryLevelSignUpBonus.ReferralAmountOverrideUSDCents }}
+          {{ globalVars.formatUSD(signUpBonus.value.CountryLevelSignUpBonus.ReferralAmountOverrideUSDCents / 100, 2) }}
         </div>
         <div class="col-2 d-flex">
           <input
@@ -84,7 +96,7 @@
           />
         </div>
         <div class="col-2 d-flex flex-column">
-          {{ signUpBonus.value.CountryLevelSignUpBonus.KickbackAmountOverrideUSDCents }}
+          {{ globalVars.formatUSD(signUpBonus.value.CountryLevelSignUpBonus.KickbackAmountOverrideUSDCents / 100, 2) }}
         </div>
         <div class="col-2">
           <input

--- a/src/app/admin/admin-jumio/admin-jumio.component.html
+++ b/src/app/admin/admin-jumio/admin-jumio.component.html
@@ -1,54 +1,98 @@
 <div>
-  <div class="fs-15px font-weight-bold mt-15px mb-15px px-15px">
-    Set Jumio Starter $DESO amount (in nanos):
-    <div class="d-flex mt-5px">
-      <input
-        [(ngModel)]="jumioDeSoNanos"
-        (keydown.enter)="updateJumioDeSoNanos()"
-        class="form-control w-100 fs-15px lh-15px"
-        placeholder="Enter an amount"
-        type="number"
-      />
-      <button *ngIf="!updatingJumioDeSoNanos" (click)="updateJumioDeSoNanos()" class="btn btn-outline-primary fs-15px ml-5px">
-        Update
-      </button>
-      <button *ngIf="updatingJumioDeSoNanos" class="btn btn-primary fs-15px ml-5px" disabled>
-        Working...
-      </button>
+  <tab-selector
+    [tabs]="tabs"
+    [activeTab]="activeTab"
+    (tabClick)="_handleTabClick($event)"></tab-selector>
+  <div class="p-15px fs-15px" *ngIf="activeTab === AdminJumioComponent.GENERAL">
+    <div class="fs-15px font-weight-bold mt-15px mb-15px px-15px">
+      Set Jumio Starter $DESO amount (in nanos):
+      <div class="d-flex mt-5px">
+        <input
+          [(ngModel)]="jumioDeSoNanos"
+          (keydown.enter)="updateJumioDeSoNanos()"
+          class="form-control w-100 fs-15px lh-15px"
+          placeholder="Enter an amount"
+          type="number"
+        />
+        <button *ngIf="!updatingJumioDeSoNanos" (click)="updateJumioDeSoNanos()" class="btn btn-outline-primary fs-15px ml-5px">
+          Update
+        </button>
+        <button *ngIf="updatingJumioDeSoNanos" class="btn btn-primary fs-15px ml-5px" disabled>
+          Working...
+        </button>
+      </div>
+    </div>
+    <div class="fs-15px font-weight-bold mt-15px mb-15px px-15px">
+      Reset Jumio for Public Key or Username:
+      <div class="d-flex mt-5px">
+        <input
+          [(ngModel)]="usernameToResetJumio"
+          (keydown.enter)="_resetJumio()"
+          class="form-control w-100 fs-15px lh-15px"
+          placeholder="Enter a username or public key."
+        />
+        <button *ngIf="!resettingJumio" (click)="_resetJumio()" class="btn btn-outline-primary fs-15px ml-5px">
+          Reset
+        </button>
+        <button *ngIf="resettingJumio" class="btn btn-primary fs-15px ml-5px" disabled>
+          Working...
+        </button>
+      </div>
+    </div>
+    <div class="fs-15px font-weight-bold mt-15px mb-15px px-15px">
+      Execute Jumio Callback for Public Key or Username:
+      <div class="d-flex mt-5px">
+        <input
+          [(ngModel)]="usernameToExecuteJumioCallback"
+          (keydown.enter)="_executeJumioCallback()"
+          class="form-control w-100 fs-15px lh-15px"
+          placeholder="Enter a username or public key."
+        />
+        <button *ngIf="!executingJumioCallback" (click)="_executeJumioCallback()" class="btn btn-outline-primary fs-15px ml-5px">
+          Execute
+        </button>
+        <button *ngIf="executingJumioCallback" class="btn btn-primary fs-15px ml-5px" disabled>
+          Working...
+        </button>
+      </div>
     </div>
   </div>
-  <div class="fs-15px font-weight-bold mt-15px mb-15px px-15px">
-    Reset Jumio for Public Key or Username:
-    <div class="d-flex mt-5px">
-      <input
-        [(ngModel)]="usernameToResetJumio"
-        (keydown.enter)="_resetJumio()"
-        class="form-control w-100 fs-15px lh-15px"
-        placeholder="Enter a username or public key."
-      />
-      <button *ngIf="!resettingJumio" (click)="_resetJumio()" class="btn btn-outline-primary fs-15px ml-5px">
-        Reset
-      </button>
-      <button *ngIf="resettingJumio" class="btn btn-primary fs-15px ml-5px" disabled>
-        Working...
-      </button>
+  <div class="p-15px fs-15px" *ngIf="activeTab === AdminJumioComponent.COUNTRY_BONUSES">
+    <div class="d-flex align-items-center">
+      <div class="col-4">Country</div>
+      <div class="col-2">Referral Amount</div>
+      <div class="col-2">Allow Referral Override</div>
+      <div class="col-2">Kickback Amount</div>
+      <div class="col-2">Allow Kickback Override</div>
     </div>
-  </div>
-  <div class="fs-15px font-weight-bold mt-15px mb-15px px-15px">
-    Execute Jumio Callback for Public Key or Username:
-    <div class="d-flex mt-5px">
-      <input
-        [(ngModel)]="usernameToExecuteJumioCallback"
-        (keydown.enter)="_executeJumioCallback()"
-        class="form-control w-100 fs-15px lh-15px"
-        placeholder="Enter a username or public key."
-      />
-      <button *ngIf="!executingJumioCallback" (click)="_executeJumioCallback()" class="btn btn-outline-primary fs-15px ml-5px">
-        Execute
-      </button>
-      <button *ngIf="executingJumioCallback" class="btn btn-primary fs-15px ml-5px" disabled>
-        Working...
-      </button>
-    </div>
+      <div *ngFor="let signUpBonus of countryLevelSignUpBonuses | keyvalue; let ii = index" class="py-15px d-flex">
+        <div class="col-4 d-flex align-items-center">
+          <i class="fa fa-pencil pr-5px"
+             aria-hidden="true"
+             (click)="editCountry(signUpBonus.value.CountryCodeDetails.Alpha3)"
+          ></i>
+          <span>{{ signUpBonus.key }}</span>
+        </div>
+        <div class="col-2 d-flex">
+          {{ countryLevelSignUpBonuses[signUpBonus.key].CountryLevelSignUpBonus.ReferralAmountOverrideUSDCents }}
+        </div>
+        <div class="col-2 d-flex">
+          <input
+            type="checkbox"
+            (ngModel)="value.CountryLevelSignUpBonus.AllowCustomReferralAmount"
+            disabled
+          />
+        </div>
+        <div class="col-2 d-flex flex-column">
+          {{ signUpBonus.value.CountryLevelSignUpBonus.KickbackAmountOverrideUSDCents }}
+        </div>
+        <div class="col-2">
+          <input
+            type="checkbox"
+            (ngModel)="value.CountryLevelSignUpBonus.AllowCustomKickbackAmount"
+            disabled
+          />
+        </div>
+      </div>
   </div>
 </div>

--- a/src/app/admin/admin-jumio/admin-jumio.component.ts
+++ b/src/app/admin/admin-jumio/admin-jumio.component.ts
@@ -145,6 +145,7 @@ export class AdminJumioComponent {
           .subscribe(
             (res) => {
               this.globalVars.jumioUSDCents = res.USDCents;
+              this.refreshCountryBonuses();
             },
             (err) => {
               console.error(err);

--- a/src/app/admin/admin-jumio/admin-jumio.component.ts
+++ b/src/app/admin/admin-jumio/admin-jumio.component.ts
@@ -1,7 +1,7 @@
 import { Component } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { GlobalVarsService } from "../../global-vars.service";
-import { BackendApiService } from "../../backend-api.service";
+import {BackendApiService, CountryLevelSignUpBonus, CountryLevelSignUpBonusResponse} from "../../backend-api.service";
 import { SwalHelper } from "../../../lib/helpers/swal-helper";
 
 @Component({
@@ -18,6 +18,15 @@ export class AdminJumioComponent {
   jumioDeSoNanos: number = 0;
   updatingJumioDeSoNanos = false;
 
+  countryLevelSignUpBonuses: { [k: string]: CountryLevelSignUpBonusResponse } = {};
+  defaultSignUpBonus: CountryLevelSignUpBonus;
+
+  static GENERAL = "General";
+  static COUNTRY_BONUSES = "Country Bonuses";
+  tabs = [AdminJumioComponent.GENERAL, AdminJumioComponent.COUNTRY_BONUSES];
+  activeTab: string = AdminJumioComponent.GENERAL;
+  AdminJumioComponent = AdminJumioComponent;
+
   constructor(
     private globalVars: GlobalVarsService,
     private router: Router,
@@ -25,6 +34,20 @@ export class AdminJumioComponent {
     private backendApi: BackendApiService
   ) {
     this.jumioDeSoNanos = globalVars.jumioDeSoNanos;
+    backendApi
+      .AdminGetAllCountryLevelSignUpBonuses(
+        this.globalVars.localNode,
+        this.globalVars.loggedInUser?.PublicKeyBase58Check
+      )
+      .subscribe(
+        (res) => {
+          this.countryLevelSignUpBonuses = res.SignUpBonusMetadata;
+          this.defaultSignUpBonus = res.DefaultSignUpBonusMetadata;
+        },
+        (err) => {
+          console.error(err);
+        }
+      );
   }
 
   _resetJumio(): void {
@@ -117,5 +140,13 @@ export class AdminJumioComponent {
           .add(() => (this.updatingJumioDeSoNanos = false));
       }
     });
+  }
+
+  _handleTabClick(tab: string): void {
+    this.activeTab = tab;
+  }
+
+  editCountry(countryCode: string): void {
+    console.log(countryCode);
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -196,6 +196,7 @@ export class AppComponent implements OnInit {
         this.globalVars.showBuyWithETH = res.BuyWithETH;
         this.globalVars.showJumio = res.HasJumioIntegration;
         this.globalVars.jumioDeSoNanos = res.JumioDeSoNanos;
+        this.globalVars.jumioUSDCents = res.JumioUSDCents;
         this.globalVars.isTestnet = res.IsTestnet;
         this.identityService.isTestnet = res.IsTestnet;
         this.globalVars.showPhoneNumberVerification = res.HasTwilioAPIKey && res.HasStarterDeSoSeed;

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -156,6 +156,7 @@ import { BuyDeSoEthComponent } from "./buy-deso-page/buy-deso-eth/buy-deso-eth.c
 import { SanitizeVideoUrlPipe } from "../lib/pipes/sanitize-video-url-pipe";
 import { AdminNodeFeesComponent } from "./admin/admin-node-fees/admin-node-fees.component";
 import { AdminNodeAddFeesComponent } from "./admin/admin-node-fees/admin-node-add-fee/admin-node-add-fees.component";
+import { FreeDesoMessageComponent } from "./free-deso-message/free-deso-message.component";
 
 // Modular Themes for DeSo by Carsen Klock @carsenk
 import { ThemeModule } from "./theme/theme.module";
@@ -301,6 +302,7 @@ const greenishTheme: Theme = { key: "greenish", name: "Green Theme" };
     SanitizeVideoUrlPipe,
     AdminNodeFeesComponent,
     AdminNodeAddFeesComponent,
+    FreeDesoMessageComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -136,6 +136,7 @@ import { NftDropMgrComponent } from "./nft-drop-mgr/nft-drop-mgr.component";
 import { NftShowcaseComponent } from "./nft-showcase/nft-showcase.component";
 import { VerifyEmailComponent } from "./verify-email/verify-email.component";
 import { AdminJumioComponent } from "./admin/admin-jumio/admin-jumio.component";
+import { AdminJumioEditCountrySignUpBonusComponent } from "./admin/admin-jumio/admin-jumio-edit-country-sign-up-bonus/admin-jumio-edit-country-sign-up-bonus.component";
 import { JumioStatusComponent } from "./jumio-status/jumio-status.component";
 import { AdminTutorialComponent } from "./admin/admin-tutorial/admin-tutorial.component";
 import { CreateProfileTutorialPageComponent } from "./tutorial/create-profile-tutorial-page/create-profile-tutorial-page.component";
@@ -281,6 +282,7 @@ const greenishTheme: Theme = { key: "greenish", name: "Green Theme" };
     NftShowcaseComponent,
     VerifyEmailComponent,
     AdminJumioComponent,
+    AdminJumioEditCountrySignUpBonusComponent,
     JumioStatusComponent,
     ReferralProgramMgrComponent,
     ReferralsComponent,

--- a/src/app/backend-api.service.ts
+++ b/src/app/backend-api.service.ts
@@ -122,6 +122,9 @@ export class BackendRoutes {
   static RoutePathAdminResetTutorialStatus = "/api/v0/admin/reset-tutorial-status";
   static RoutePathAdminGetTutorialCreators = "/api/v0/admin/get-tutorial-creators";
   static RoutePathAdminJumioCallback = "/api/v0/admin/jumio-callback";
+  static RoutePathAdminGetAllCountryLevelSignUpBonuses = "/api/v0/admin/get-all-country-level-sign-up-bonuses";
+  static RoutePathAdminUpdateJumioCountrySignUpBonus = "/api/v0/admin/update-jumio-country-sign-up-bonus";
+  static RoutePathAdminUpdateJumioUSDCents = "/api/v0/admin/update-jumio-usd-cents";
 
   // Referral program admin routes.
   static RoutePathAdminCreateReferralHash = "/api/v0/admin/create-referral-hash";
@@ -395,6 +398,24 @@ type GetUsersStatelessResponse = {
   UserList: User[];
   DefaultFeeRateNanosPerKB: number;
   ParamUpdaters: { [k: string]: boolean };
+};
+
+export type CountryLevelSignUpBonus = {
+  AllowCustomReferralAmount: boolean;
+  ReferralAmountOverrideUSDCents: number;
+  AllowCustomKickbackAmount: boolean;
+  KickbackAmountOverrideUSDCents: number;
+};
+
+export type CountryCodeDetails = {
+  Name: string;
+  CountryCode: string;
+  Alpha3: string;
+};
+
+export type CountryLevelSignUpBonusResponse = {
+  CountryLevelSignUpBonus: CountryLevelSignUpBonus;
+  CountryCodeDetails: CountryCodeDetails;
 };
 
 @Injectable({
@@ -1989,6 +2010,13 @@ export class BackendApiService {
     });
   }
 
+  AdminUpdateJumioUSDCents(endpoint: string, AdminPublicKey: string, USDCents: number): Observable<any> {
+    return this.jwtPost(endpoint, BackendRoutes.RoutePathAdminUpdateJumioUSDCents, AdminPublicKey, {
+      AdminPublicKey,
+      USDCents,
+    });
+  }
+
   AdminJumioCallback(
     endpoint: string,
     AdminPublicKey: string,
@@ -1999,6 +2027,31 @@ export class BackendApiService {
       PublicKeyBase58Check,
       Username,
       AdminPublicKey,
+    });
+  }
+
+  AdminGetAllCountryLevelSignUpBonuses(
+    endpoint: string,
+    AdminPublicKey: string
+  ): Observable<{
+    SignUpBonusMetadata: { [k: string]: CountryLevelSignUpBonusResponse };
+    DefaultSignUpBonusMetadata: CountryLevelSignUpBonus;
+  }> {
+    return this.jwtPost(endpoint, BackendRoutes.RoutePathAdminGetAllCountryLevelSignUpBonuses, AdminPublicKey, {
+      AdminPublicKey,
+    });
+  }
+
+  AdminUpdateJumioCountrySignUpBonus(
+    endpoint: string,
+    AdminPublicKey: string,
+    CountryCode: string,
+    CountryLevelSignUpBonus: CountryLevelSignUpBonus
+  ): Observable<any> {
+    return this.jwtPost(endpoint, BackendRoutes.RoutePathAdminUpdateJumioCountrySignUpBonus, AdminPublicKey, {
+      AdminPublicKey,
+      CountryCode,
+      CountryLevelSignUpBonus,
     });
   }
 

--- a/src/app/backend-api.service.ts
+++ b/src/app/backend-api.service.ts
@@ -2021,12 +2021,14 @@ export class BackendApiService {
     endpoint: string,
     AdminPublicKey: string,
     PublicKeyBase58Check: string,
-    Username: string
+    Username: string,
+    CountryAlpha3: string = ""
   ): Observable<any> {
     return this.jwtPost(endpoint, BackendRoutes.RoutePathAdminJumioCallback, AdminPublicKey, {
       PublicKeyBase58Check,
       Username,
       AdminPublicKey,
+      CountryAlpha3,
     });
   }
 

--- a/src/app/free-deso-message/free-deso-message.component.html
+++ b/src/app/free-deso-message/free-deso-message.component.html
@@ -1,0 +1,12 @@
+<b>
+  <span>{{ globalVars.getFreeDESOMessage() }}</span>
+  <sup style="padding-left: 1px">
+    <i
+      (click)="tooltip1.toggle()"
+      class="fas fa-info-circle text-greyC global__tooltip-icon"
+      matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
+      matTooltip="Amount may vary based on ID"
+      #tooltip1="matTooltip"
+    ></i>
+  </sup>
+</b>

--- a/src/app/free-deso-message/free-deso-message.component.html
+++ b/src/app/free-deso-message/free-deso-message.component.html
@@ -2,10 +2,10 @@
   <span>{{ globalVars.getFreeDESOMessage() }}</span>
   <sup style="padding-left: 1px">
     <i
-      (click)="tooltip1.toggle()"
+      (click)="$event.stopPropagation(); tooltip1.show();"
       class="fas fa-info-circle text-greyC global__tooltip-icon"
       matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
-      matTooltip="Amount may vary based on ID"
+      matTooltip="Amount may vary based on locality of ID"
       #tooltip1="matTooltip"
     ></i>
   </sup>

--- a/src/app/free-deso-message/free-deso-message.component.ts
+++ b/src/app/free-deso-message/free-deso-message.component.ts
@@ -1,0 +1,10 @@
+import { Component } from "@angular/core";
+import { GlobalVarsService } from "../global-vars.service";
+
+@Component({
+  selector: "free-deso-message",
+templateUrl: "./free-deso-message.component.html",
+})
+export class FreeDesoMessageComponent {
+  constructor(public globalVars: GlobalVarsService) {}
+}

--- a/src/app/global-vars.service.ts
+++ b/src/app/global-vars.service.ts
@@ -213,6 +213,7 @@ export class GlobalVarsService {
   profileUpdateTimestamp: number;
 
   jumioDeSoNanos = 0;
+  jumioUSDCents = 0;
 
   referralUSDCents: number = 0;
 
@@ -1174,7 +1175,7 @@ export class GlobalVarsService {
   getFreeDESOMessage(): string {
     return this.referralUSDCents
       ? this.formatUSD(this.referralUSDCents / 100, 0)
-      : this.nanosToUSD(this.jumioDeSoNanos, 0);
+      : this.formatUSD(this.jumioUSDCents / 100, 0);
   }
 
   getReferralUSDCents(): void {

--- a/src/app/jumio-status/jumio-status.component.html
+++ b/src/app/jumio-status/jumio-status.component.html
@@ -6,7 +6,7 @@
       ⌛
     </div>
     <div style="width: calc(100% - 4rem); text-align: center;">
-      Your free <b>{{ globalVars.getFreeDESOMessage() }}</b> will arrive in <b>about a minute</b>.
+      Your free <free-deso-message></free-deso-message> will arrive in <b>about a minute</b>.
     </div>
     <div class="fs-20px">
       ⌛
@@ -19,7 +19,7 @@
       💰
     </div>
     <div style="width: calc(100% - 4rem); text-align: center;">
-      <span class="cursor-pointer font-weight-bold" style="color: var(--link);">Click here</span> to get your <b>free {{ globalVars.getFreeDESOMessage() }}</b>.
+      <span class="cursor-pointer font-weight-bold" style="color: var(--link);">Click here</span> to get your <b>free <free-deso-message></free-deso-message></b>.
     </div>
     <div class="fs-20px">
       💰

--- a/src/app/landing-page/landing-page.component.html
+++ b/src/app/landing-page/landing-page.component.html
@@ -23,7 +23,7 @@
 </div>
 <div class="w-100 d-lg-none d-flex align-items-center justify-content-center">
   <a class="landing__nav-link" (click)="globalVars.launchSignupFlow()">
-    Sign Up and Get <b>{{ globalVars.getFreeDESOMessage() }} Free</b>
+    Sign Up and Get <free-deso-message></free-deso-message><b>Free</b>
   </a>
 </div>
 
@@ -33,7 +33,7 @@
       <div class="col landing__logo deso" [ngStyle]="{'background': getLogoBackground()}"></div>
       <div class="col d-lg-flex d-none align-items-center">
         <a class="landing__nav-link" (click)="globalVars.launchSignupFlow()">
-          Sign Up and Get <b>{{ globalVars.getFreeDESOMessage() }} Free</b>
+          Sign Up and Get <free-deso-message></free-deso-message><b>Free</b>
         </a>
       </div>
       <div class="d-flex align-items-center">
@@ -76,7 +76,7 @@
             Sign Up
           </div>
           <div class="mt-1 fs-15px">
-            Get {{ globalVars.getFreeDESOMessage() }} Free
+            Get <free-deso-message></free-deso-message> Free
           </div>
         </a>
         <a class="landing__log-in d-none d-sm-block" (click)="globalVars.launchLoginFlow()" style="font-size: 15px;">Log in</a>

--- a/src/app/trade-creator-page/trade-creator/trade-creator.component.ts
+++ b/src/app/trade-creator-page/trade-creator/trade-creator.component.ts
@@ -204,7 +204,8 @@ export class TradeCreatorComponent implements OnInit {
 
   setUpBuyTutorial(): void {
     let balance = this.appData.loggedInUser?.BalanceNanos;
-    const jumioDeSoNanos = this.appData.jumioDeSoNanos > 0 ? this.appData.jumioDeSoNanos : 1e8;
+    const jumioDeSoNanos =
+      this.appData.jumioUSDCents > 0 ? this.appData.usdToNanosNumber(this.appData.jumioUSDCents / 100) : 1e8;
     balance = balance > jumioDeSoNanos ? jumioDeSoNanos : balance;
     const percentToBuy =
       this.creatorProfile.PublicKeyBase58Check === this.globalVars.loggedInUser.PublicKeyBase58Check ? 0.1 : 0.5;


### PR DESCRIPTION
depends upon https://github.com/deso-protocol/backend/pull/242

**What's been done:**

- Add admin functionality to manage the sign-up bonus configuration at a country level
- Use JumioUSDCents instead of JumioDeSoNanos for calculating sign up bonus.

Management UI
![image](https://user-images.githubusercontent.com/81658138/146065924-c404bff2-9358-4347-9b19-8782bafdbc60.png)
![image](https://user-images.githubusercontent.com/81658138/146066363-eab3e9c1-462a-4aa5-b4ed-232d79e25430.png)

Free DESO Message Tooltip Disclaimer
![Screenshot from 2021-12-14 14-26-51](https://user-images.githubusercontent.com/81658138/146066276-71c38e51-54d7-483d-9f64-20aaf1c7bcdb.png)
