### PR TITLE
add support for NFT transfers, burns, and acceptance of transfers

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -157,16 +157,16 @@ import { SanitizeVideoUrlPipe } from "../lib/pipes/sanitize-video-url-pipe";
 import { AdminNodeFeesComponent } from "./admin/admin-node-fees/admin-node-fees.component";
 import { AdminNodeAddFeesComponent } from "./admin/admin-node-fees/admin-node-add-fee/admin-node-add-fees.component";
 import { FreeDesoMessageComponent } from "./free-deso-message/free-deso-message.component";
+import { SupplyMonitoringStatsPageComponent } from "./supply-monitoring-stats-page/supply-monitoring-stats-page.component";
+import { SupplyMonitoringStatsComponent } from "./supply-monitoring-stats-page/supply-monitoring-stats/supply-monitoring-stats.component";
+import { TransferNftModalComponent } from "./transfer-nft-modal/transfer-nft-modal.component";
+import { TransferNftAcceptModalComponent } from "./transfer-nft-accept-modal/transfer-nft-accept-modal.component";
+import { NftBurnModalComponent } from "./nft-burn-modal/nft-burn-modal.component";
+import { NftSelectSerialNumberComponent } from "./nft-select-serial-number/nft-select-serial-number.component";
 
 // Modular Themes for DeSo by Carsen Klock @carsenk
 import { ThemeModule } from "./theme/theme.module";
 import { Theme } from "./theme/symbols";
-import {
-  SupplyMonitoringStatsPageComponent
-} from "./supply-monitoring-stats-page/supply-monitoring-stats-page.component";
-import {
-  SupplyMonitoringStatsComponent
-} from "./supply-monitoring-stats-page/supply-monitoring-stats/supply-monitoring-stats.component";
 const lightTheme: Theme = { key: "light", name: "Light Theme" };
 const darkTheme: Theme = { key: "dark", name: "Dark Theme" };
 const icydarkTheme: Theme = { key: "icydark", name: "Icy Dark Theme" };
@@ -311,6 +311,10 @@ const greenishTheme: Theme = { key: "greenish", name: "Green Theme" };
     SupplyMonitoringStatsPageComponent,
     SupplyMonitoringStatsComponent,
     FreeDesoMessageComponent,
+    TransferNftAcceptModalComponent,
+    TransferNftModalComponent,
+    NftBurnModalComponent,
+    NftSelectSerialNumberComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/close-nft-auction-modal/close-nft-auction-modal.component.ts
+++ b/src/app/close-nft-auction-modal/close-nft-auction-modal.component.ts
@@ -52,8 +52,8 @@ export class CloseNftAuctionModalComponent {
       .subscribe(
         (res) => {
           // Hide this modal and open the next one.
-          this.bsModalRef.hide();
           this.modalService.setDismissReason("auction cancelled");
+          this.bsModalRef.hide();
         },
         (err) => {
           console.error(err);

--- a/src/app/create-nft-auction-modal/create-nft-auction-modal.component.ts
+++ b/src/app/create-nft-auction-modal/create-nft-auction-modal.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from "@angular/core";
-import { BsModalRef } from "ngx-bootstrap/modal";
+import { BsModalRef, BsModalService } from "ngx-bootstrap/modal";
 import { GlobalVarsService } from "../global-vars.service";
 import { BackendApiService, NFTEntryResponse, PostEntryResponse } from "../backend-api.service";
 import { concatMap, last, map } from "rxjs/operators";
@@ -25,6 +25,7 @@ export class CreateNftAuctionModalComponent {
     private backendApi: BackendApiService,
     public globalVars: GlobalVarsService,
     public bsModalRef: BsModalRef,
+    private modalService: BsModalService,
     private router: Router
   ) {}
 
@@ -70,6 +71,7 @@ export class CreateNftAuctionModalComponent {
       .subscribe(
         (res) => {
           this.router.navigate(["/" + this.globalVars.RouteNames.NFT + "/" + this.post.PostHashHex]);
+          this.modalService.setDismissReason("auction created");
           this.bsModalRef.hide();
         },
         (err) => {

--- a/src/app/create-nft-auction-modal/create-nft-auction-modal.component.ts
+++ b/src/app/create-nft-auction-modal/create-nft-auction-modal.component.ts
@@ -86,6 +86,7 @@ export class CreateNftAuctionModalComponent {
     return this.nftEntryResponses.filter(
       (nftEntryResponse) =>
         !nftEntryResponse.IsForSale &&
+        !nftEntryResponse.IsPending &&
         nftEntryResponse.OwnerPublicKeyBase58Check === this.globalVars.loggedInUser?.PublicKeyBase58Check
     );
   }

--- a/src/app/creator-profile-page/creator-profile-nfts/creator-profile-nfts.component.html
+++ b/src/app/creator-profile-page/creator-profile-nfts/creator-profile-nfts.component.html
@@ -48,6 +48,32 @@
 </div>
 <div
   *ngIf="
+    !showProfileAsReserved && !isLoading && !nftResponse?.length && activeTab === CreatorProfileNftsComponent.TRANSFERABLE
+  "
+  class="p-15px"
+>
+  <div class="background-color-grey p-35px br-12px d-flex flex-row align-items-center" style="text-align: center">
+    <span *ngIf="profileBelongsToLoggedInUser(); else elseMissingPostBlock">No transferable NFTs right now.</span>
+    <ng-template #elseMissingPostBlock>
+      <span>@{{ profile.Username }} has no transferable NFTs yet.</span>
+    </ng-template>
+  </div>
+</div>
+<div
+  *ngIf="
+    !showProfileAsReserved && !isLoading && !nftResponse?.length && activeTab === CreatorProfileNftsComponent.MY_PENDING_TRANSFERS
+  "
+  class="p-15px"
+>
+  <div class="background-color-grey p-35px br-12px d-flex flex-row align-items-center" style="text-align: center">
+    <span *ngIf="profileBelongsToLoggedInUser(); else elseMissingPostBlock">No pending NFTs right now.</span>
+    <ng-template #elseMissingPostBlock>
+      <span>@{{ profile.Username }} has no pending NFTs yet.</span>
+    </ng-template>
+  </div>
+</div>
+<div
+  *ngIf="
     !showProfileAsReserved && !isLoading && !myBids?.length && activeTab === CreatorProfileNftsComponent.MY_BIDS
   "
   class="p-15px"
@@ -69,6 +95,12 @@
     </div>
     <div *ngIf="activeTab === CreatorProfileNftsComponent.FOR_SALE && nftResponse?.length">
       NFTs that @{{ profile.Username }} is currently selling
+    </div>
+    <div *ngIf="activeTab === CreatorProfileNftsComponent.TRANSFERABLE && nftResponse?.length">
+      NFTs that @{{ profile.Username }} can transfer
+    </div>
+    <div *ngIf="activeTab === CreatorProfileNftsComponent.MY_PENDING_TRANSFERS && nftResponse?.length">
+      Transferred NFTs pending acceptance by @{{ profile.Username }}
     </div>
   </div>
   <div *ngIf="!globalVars.hasUserBlockedCreator(profile.PublicKeyBase58Check)">
@@ -96,6 +128,7 @@
         [cardStyle]="true"
         [profilePublicKeyBase58Check]="profile.PublicKeyBase58Check"
         [isForSaleOnly]="activeTab === CreatorProfileNftsComponent.FOR_SALE"
+        [acceptNFT]="activeTab === CreatorProfileNftsComponent.MY_PENDING_TRANSFERS"
         (userBlocked)="userBlocked()"
       ></feed-post>
       <div *ngIf="activeTab === CreatorProfileNftsComponent.MY_BIDS && nftEntry.PostEntryResponse">

--- a/src/app/feed/feed-post-dropdown/feed-post-dropdown.component.html
+++ b/src/app/feed/feed-post-dropdown/feed-post-dropdown.component.html
@@ -12,7 +12,7 @@
       (click)="copyPostLinkToClipboard($event)"
     >
       <i class="icon-link"></i>
-      Link to Post
+      Link to {{ post.IsNFT ? "NFT" : "Post" }}
     </a>
     <a
       *ngIf="showSharePost"
@@ -20,7 +20,7 @@
       (click)="sharePostUrl($event)"
       >
       <i class="fas fa-share-square"></i>
-      Share Post
+      Share {{ post.IsNFT ? "NFT" : "Post" }}
     </a>
     <a
       *ngIf="globalVars.loggedInUser.PublicKeyBase58Check === post.PosterPublicKeyBase58Check && !post.IsNFT && !post.ParentStakeID"
@@ -35,7 +35,24 @@
       class="dropdown-menu-item fs-12px d-block link--unstyled p-10px feed-post__dropdown-menu-item text-success"
       (click)="openCreateNFTAuctionModal($event)"
     >
+      <i class="fas fa-dollar-sign"></i>
       Put On Sale
+    </a>
+    <a
+      *ngIf="showTransferNFT()"
+      class="dropdown-menu-item fs-12px d-block link--unstyled p-10px feed-post__dropdown-menu-item"
+      (click)="openTransferNFTModal($event)"
+    >
+      <i class="fas fa-paper-plane"></i>
+      Transfer NFT
+    </a>
+    <a
+      *ngIf="showBurnNFT()"
+      class="dropdown-menu-item fs-12px d-block link--unstyled p-10px feed-post__dropdown-menu-item"
+      (click)="openBurnNFTModal($event)"
+    >
+      <i class="fa fa-fire"></i>
+      Burn NFT
     </a>
     <a
       *ngIf="post.IsNFT && globalVars.showAdminTools()"

--- a/src/app/feed/feed-post/feed-post.component.html
+++ b/src/app/feed/feed-post/feed-post.component.html
@@ -105,6 +105,7 @@
             (postHidden)="hidePost()"
             (userBlocked)="blockUser()"
             (toggleGlobalFeed)="_addPostToGlobalFeed()"
+            (refreshNFTEntries)="refreshNFTEntriesHandler()"
           ></feed-post-dropdown>
         </div>
 
@@ -225,6 +226,7 @@
                   (userBlocked)="blockUser()"
                   (toggleGlobalFeed)="_addPostToGlobalFeed($event)"
                   (togglePostPin)="_pinPostToGlobalFeed($event)"
+                  (refreshNFTEntries)="refreshNFTEntriesHandler()"
                 ></feed-post-dropdown>
               </div>
             </div>
@@ -538,6 +540,16 @@
         *ngIf="showPlaceABid"
       >
         Place a bid
+      </button>
+      <button
+        class="btn btn-primary font-weight-bold br-8px fs-13px"
+        [ngClass]="{ 'mt-15px': isQuotedContent }"
+        (click)="acceptTransfer($event)"
+        *ngIf="acceptNFT"
+      >
+            <span class="d-flex align-items-center justify-content-center fs-12px">
+              Accept Transfer
+            </span>
       </button>
     </div>
     <div *ngIf="showUnlockableContent">

--- a/src/app/feed/feed-post/feed-post.component.ts
+++ b/src/app/feed/feed-post/feed-post.component.ts
@@ -16,6 +16,7 @@ import { PlaceBidModalComponent } from "../../place-bid-modal/place-bid-modal.co
 import { EmbedUrlParserService } from "../../../lib/services/embed-url-parser-service/embed-url-parser-service";
 import { SharedDialogs } from "../../../lib/shared-dialogs";
 import { environment } from "src/environments/environment";
+import { TransferNftAcceptModalComponent } from "../../transfer-nft-accept-modal/transfer-nft-accept-modal.component";
 
 @Component({
   selector: "feed-post",
@@ -111,6 +112,9 @@ export class FeedPostComponent implements OnInit {
 
   @Input() inTutorial: boolean = false;
 
+  // If this is a pending NFT post that still needs to be accepted by the user
+  @Input() acceptNFT: boolean = false;
+
   // emits the PostEntryResponse
   @Output() postDeleted = new EventEmitter();
 
@@ -122,6 +126,9 @@ export class FeedPostComponent implements OnInit {
 
   // emits diamondSent event
   @Output() diamondSent = new EventEmitter();
+
+  // Emit tells parent component to refresh NFT data
+  @Output() refreshNFTEntries = new EventEmitter();
 
   AppRoutingModule = AppRoutingModule;
   addingPostToGlobalFeed = false;
@@ -204,6 +211,11 @@ export class FeedPostComponent implements OnInit {
           }
         }
       });
+  }
+
+  refreshNFTEntriesHandler() {
+    this.getNFTEntries();
+    this.refreshNFTEntries.emit();
   }
 
   ngOnInit() {
@@ -545,6 +557,30 @@ export class FeedPostComponent implements OnInit {
       return imgURL.replace("https://i.imgur.com", "https://images.bitclout.com/i.imgur.com");
     }
     return imgURL;
+  }
+
+  acceptTransfer(event) {
+    event.stopPropagation();
+    const transferNFTEntryResponses = _.filter(this.nftEntryResponses, (nftEntryResponse: NFTEntryResponse) => {
+      return (
+        nftEntryResponse.OwnerPublicKeyBase58Check === this.globalVars.loggedInUser.PublicKeyBase58Check &&
+        nftEntryResponse.IsPending
+      );
+    });
+
+    const modalDetails = this.modalService.show(TransferNftAcceptModalComponent, {
+      class: "modal-dialog-centered modal-lg",
+      initialState: {
+        post: this.postContent,
+        transferNFTEntryResponses,
+      },
+    });
+    const onHideEvent = modalDetails.onHide;
+    onHideEvent.subscribe((response) => {
+      if (response === "transfer accepted") {
+        this.getNFTEntries();
+      }
+    });
   }
 
   openPlaceBidModal(event: any) {

--- a/src/app/nft-burn-modal/nft-burn-modal.component.html
+++ b/src/app/nft-burn-modal/nft-burn-modal.component.html
@@ -1,0 +1,104 @@
+<div app-theme class="nft-modal-container p-15px">
+  <nft-modal-header [header]="isSelectingSerialNumber ? 'Select an edition' : 'Confirm burn'" [bsModalRef]="bsModalRef"></nft-modal-header>
+  <simple-center-loader *ngIf="loading"></simple-center-loader>
+  <div *ngIf="!loading">
+    <div *ngIf="filteredSerialNumbers?.length" [ngClass]="{ 'd-none': isSelectingSerialNumber }">
+      <div class="fs-15px text-grey5">
+        You are about to permanently burn your NFT. <b>This NFT will no longer exist - this action cannot be undone.</b>
+      </div>
+
+      <div *ngIf="!globalVars.isMobile()" class="d-flex justify-content-between nft-modal-bid-details">
+        <div class="col-2 d-flex flex-column m-16px" style="border-right: 1px solid var(--border)">
+          <span>Number</span>
+          <span class="mt-5px">#{{ selectedSerialNumber?.SerialNumber }}</span>
+        </div>
+        <div class="col-5 d-flex flex-column m-16px" style="border-right: 1px solid var(--border)">
+          <span>Highest Bid</span>
+          <span class="mt-5px">{{ globalVars.nanosToDeSo(highBid) }} DESO (~{{globalVars.nanosToUSD(highBid, 2)}})</span>
+        </div>
+        <div class="col-5 d-flex flex-column m-16px">
+          <span>Min Bid Amount</span>
+          <span class="mt-5px">{{ globalVars.nanosToDeSo(selectedSerialNumber?.MinBidAmountNanos) }} DESO (~{{globalVars.nanosToUSD(selectedSerialNumber?.MinBidAmountNanos, 2)}})</span>
+        </div>
+      </div>
+
+      <div *ngIf="globalVars.isMobile()">
+        <div class="nft-modal-bid-details d-flex justify-content-between p-16px">
+          <span class="font-weight-bold">Number</span>
+          <div>
+            <span class="mt-5px">#{{ selectedSerialNumber?.SerialNumber }}</span>
+            <a class="fc-blue ml-16px" (click)="goBackToSerialSelection()">Change</a>
+          </div>
+        </div>
+        <div class="nft-modal-bid-details d-flex flex-column justify-content-center p-16px">
+          <div class="border-bottom pb-10px d-flex justify-content-between">
+            <span class="font-weight-bold">Highest Bid</span>
+            <span>
+              {{ globalVars.nanosToDeSo(highBid) }} DESO (~{{ globalVars.nanosToUSD(highBid, 2) }})
+            </span>
+          </div>
+          <div class="pt-10px d-flex justify-content-between">
+            <span class="font-weight-bold">Min Bid Amount</span>
+            <span>
+              {{ globalVars.nanosToDeSo(selectedSerialNumber?.MinBidAmountNanos) }} DESO (~{{
+                globalVars.nanosToUSD(selectedSerialNumber?.MinBidAmountNanos, 2)
+              }})
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Second separator line -->
+      <div class="py-16px d-flex align-items-center fs-15px text-grey7">
+        <div class="flex-grow-1 nft-modal-separator-2"></div>
+      </div>
+
+      <feed-post
+        [post]="post"
+        [includePaddingOnPost]="true"
+        [isParentPostInThread]="true"
+        [showLeftSelectedBorder]="false"
+        [showInteractionDetails]="false"
+        [contentShouldLinkToThread]="false"
+      ></feed-post>
+
+      <div *ngFor="let error of errors" class="error-container" style="white-space: pre-line;">
+        <i class="fa fa-circle-exclamation"></i>
+        {{ error }}
+      </div>
+      <div
+        [ngClass]="{
+          'floating-bottom-bar': globalVars.isMobile(),
+          'mb-15px': !globalVars.isMobile(),
+          'mt-30px': !globalVars.isMobile()
+        }"
+        class="d-flex align-items-center"
+      >
+        <button
+          class="primary-button font-weight-bold fs-15px br-12px"
+          style="height: 48px; width: 140px; line-height: 15px"
+          (click)="burnNft()"
+          [disabled]="burningNft"
+          [class]="{ 'disabled-button': burningNft }"
+        >
+          {{ burningNft ? "Burning NFT" : "Burn NFT" }}
+        </button>
+      </div>
+
+    </div>
+
+
+    <div *ngIf="filteredSerialNumbers?.length" [ngClass]="{'d-none': !isSelectingSerialNumber}">
+      <div class="nft-modal__subtitle">Choose the serial number you wish to burn.</div>
+      <div class="container fs-15px px-0px">
+        <nft-select-serial-number
+          [serialNumbers]="filteredSerialNumbers"
+          (serialNumberSelected)="selectSerialNumber($event)"
+        ></nft-select-serial-number>
+      </div>
+    </div>
+    <div *ngIf="!filteredSerialNumbers.length" class="fs-15px">
+      There are no serial numbers available for you to bid on.
+    </div>
+  </div>
+</div>

--- a/src/app/nft-burn-modal/nft-burn-modal.component.html
+++ b/src/app/nft-burn-modal/nft-burn-modal.component.html
@@ -75,11 +75,10 @@
         class="d-flex align-items-center"
       >
         <button
-          class="primary-button font-weight-bold fs-15px br-12px"
-          style="height: 48px; width: 140px; line-height: 15px"
+          class="btn btn-primary font-weight-bold fs-15px br-12px"
+          style="height: 36px; width: 140px; line-height: 15px"
           (click)="burnNft()"
           [disabled]="burningNft"
-          [class]="{ 'disabled-button': burningNft }"
         >
           {{ burningNft ? "Burning NFT" : "Burn NFT" }}
         </button>

--- a/src/app/nft-burn-modal/nft-burn-modal.component.ts
+++ b/src/app/nft-burn-modal/nft-burn-modal.component.ts
@@ -1,0 +1,151 @@
+import { Component, OnInit, Input, Output, EventEmitter } from "@angular/core";
+import { GlobalVarsService } from "../global-vars.service";
+import { BackendApiService, NFTEntryResponse, PostEntryResponse } from "../backend-api.service";
+import { Router } from "@angular/router";
+import { isNumber } from "lodash";
+import { ToastrService } from "ngx-toastr";
+import {BsModalRef, BsModalService} from "ngx-bootstrap/modal";
+import { Location } from "@angular/common";
+import { SwalHelper } from "../../lib/helpers/swal-helper";
+
+@Component({
+  selector: "nft-burn-modal",
+  templateUrl: "./nft-burn-modal.component.html",
+})
+export class NftBurnModalComponent implements OnInit {
+  static PAGE_SIZE = 50;
+  static BUFFER_SIZE = 10;
+  static WINDOW_VIEWPORT = false;
+  static PADDING = 0.5;
+
+  @Input() postHashHex: string;
+  @Input() post: PostEntryResponse;
+  @Input() burnNFTEntryResponses: NFTEntryResponse[];
+  @Output() closeModal = new EventEmitter<any>();
+  @Output() changeTitle = new EventEmitter<string>();
+
+  bidAmountDeSo: number;
+  bidAmountUSD: number;
+  selectedSerialNumber: NFTEntryResponse = null;
+  availableCount: number;
+  availableSerialNumbers: NFTEntryResponse[];
+  filteredSerialNumbers: NFTEntryResponse[];
+  highBid: number = null;
+  lowBid: number = null;
+  loading = true;
+  isSelectingSerialNumber = true;
+  saveSelectionDisabled = false;
+  showSelectedSerialNumbers = false;
+  burningNft: boolean = false;
+  errors: string[] = [];
+  minBidCurrency: string = "USD";
+  minBidInput: number = 0;
+  transferringUser: string;
+
+  constructor(
+    public globalVars: GlobalVarsService,
+    private backendApi: BackendApiService,
+    private modalService: BsModalService,
+    private router: Router,
+    private toastr: ToastrService,
+    private location: Location,
+    public bsModalRef: BsModalRef
+  ) {}
+
+  ngOnInit(): void {
+    this.backendApi
+      .GetNFTCollectionSummary(
+        this.globalVars.localNode,
+        this.globalVars.loggedInUser.PublicKeyBase58Check,
+        this.post.PostHashHex
+      )
+      .subscribe((res) => {
+        this.availableSerialNumbers = Object.values(res.SerialNumberToNFTEntryResponse);
+        this.availableCount = res.NFTCollectionResponse.PostEntryResponse.NumNFTCopiesForSale;
+        this.filteredSerialNumbers = this.burnNFTEntryResponses;
+      })
+      .add(() => (this.loading = false));
+  }
+
+  burnNft() {
+    this.saveSelectionDisabled = true;
+    this.burningNft = true;
+    SwalHelper.fire({
+      target: this.globalVars.getTargetComponentSelector(),
+      title: "Burn NFT",
+      html: `You are about to burn this NFT - this cannot be undone. Are you sure?`,
+      showConfirmButton: true,
+      showCancelButton: true,
+      reverseButtons: true,
+      customClass: {
+        confirmButton: "btn btn-light",
+        cancelButton: "btn btn-light no",
+      },
+      confirmButtonText: "Ok",
+      cancelButtonText: "Cancel",
+    }).then((res) => {
+      if (res.isConfirmed) {
+        this.backendApi
+          .BurnNFT(
+            this.globalVars.localNode,
+            this.globalVars.loggedInUser.PublicKeyBase58Check,
+            this.post.PostHashHex,
+            this.selectedSerialNumber.SerialNumber,
+            this.globalVars.defaultFeeRateNanosPerKB
+          )
+          .subscribe(
+            (res) => {
+              this.modalService.setDismissReason("nft burned");
+              this.bsModalRef.hide();
+              this.toastr.show("Your nft was burned", null, {
+                toastClass: "info-toast",
+                positionClass: "toast-bottom-center",
+              });
+            },
+            (err) => {
+              console.error(err);
+            }
+          )
+          .add(() => {
+            this.burningNft = false;
+            this.saveSelectionDisabled = false;
+          });
+      } else {
+        this.burningNft = false;
+        this.saveSelectionDisabled = false;
+      }
+    });
+  }
+
+  saveSelection(): void {
+    if (!this.saveSelectionDisabled) {
+      this.isSelectingSerialNumber = false;
+      this.showSelectedSerialNumbers = true;
+      this.changeTitle.emit("Confirm Transfer");
+      this.highBid = this.selectedSerialNumber.HighestBidAmountNanos;
+      this.lowBid = this.selectedSerialNumber.LowestBidAmountNanos;
+    }
+  }
+
+  goBackToSerialSelection(): void {
+    this.isSelectingSerialNumber = true;
+    this.showSelectedSerialNumbers = false;
+    this.changeTitle.emit("Choose an edition");
+    this.highBid = null;
+    this.lowBid = null;
+    this.selectedSerialNumber = null;
+  }
+
+  selectSerialNumber(serialNumber: NFTEntryResponse) {
+    this.selectedSerialNumber = serialNumber;
+    this.saveSelection();
+  }
+
+  bidAmountUSDFormatted() {
+    return isNumber(this.bidAmountUSD) ? `~${this.globalVars.formatUSD(this.bidAmountUSD, 0)}` : "";
+  }
+
+  bidAmountDeSoFormatted() {
+    return isNumber(this.bidAmountDeSo) ? `~${this.bidAmountDeSo.toFixed(2)} $DESO` : "";
+  }
+}

--- a/src/app/nft-post-page/nft-post/nft-post.component.html
+++ b/src/app/nft-post-page/nft-post/nft-post.component.html
@@ -216,7 +216,7 @@
               <i class="fas fa-check-circle fa-md align-middle"></i>
             </span>
                 </div>
-                <div class="fc-red" *ngIf="owner.IsPending"><i>Pending</i></div>
+                <div class="text-grey9" *ngIf="owner.IsPending"><i>Pending</i></div>
                 <div class="text-grey9" *ngIf="owner.ProfileEntryResponse">
                   {{ globalVars.nanosToUSD(owner.ProfileEntryResponse.CoinPriceDeSoNanos, 2) }}
                 </div>

--- a/src/app/nft-post-page/nft-post/nft-post.component.html
+++ b/src/app/nft-post-page/nft-post/nft-post.component.html
@@ -11,8 +11,8 @@
   </div>
 
   <div class="global__top-bar__height"></div>
-  <simple-center-loader *ngIf="isLoading"></simple-center-loader>
-  <div *ngIf="nftPost && nftBidData">
+  <simple-center-loader *ngIf="loading"></simple-center-loader>
+  <div *ngIf="nftPost && nftBidData && !loading">
     <!--  afterCommentCreatedCallback explanation: Here, the "post" is a top-level post. A new comment on a -->
     <!--  top-level post should be prepended to the post's list of comments -->
     <feed-post

--- a/src/app/nft-post-page/nft-post/nft-post.component.html
+++ b/src/app/nft-post-page/nft-post/nft-post.component.html
@@ -28,6 +28,7 @@
       [afterCommentCreatedCallback]="incrementCommentCounter.bind(this)"
       (userBlocked)="afterUserBlocked($event)"
       (nftBidPlaced)="afterNftBidPlaced($event)"
+      (refreshNFTEntries)="refreshPosts()"
     ></feed-post>
   </div>
   <div class="borderbg feed-post__blue-border" *ngIf="!loading">
@@ -215,6 +216,7 @@
               <i class="fas fa-check-circle fa-md align-middle"></i>
             </span>
                 </div>
+                <div class="fc-red" *ngIf="owner.IsPending"><i>Pending</i></div>
                 <div class="text-grey9" *ngIf="owner.ProfileEntryResponse">
                   {{ globalVars.nanosToUSD(owner.ProfileEntryResponse.CoinPriceDeSoNanos, 2) }}
                 </div>

--- a/src/app/nft-post-page/nft-post/nft-post.component.ts
+++ b/src/app/nft-post-page/nft-post/nft-post.component.ts
@@ -160,6 +160,9 @@ export class NftPostComponent {
           if (!this.nftBidData.BidEntryResponses) {
             this.nftBidData.BidEntryResponses = [];
           }
+          if (!this.nftBidData.NFTEntryResponses) {
+            this.nftBidData.NFTEntryResponses = [];
+          }
           this.availableSerialNumbers = this.nftBidData.NFTEntryResponses.filter(
             (nftEntryResponse) => nftEntryResponse.IsForSale
           );

--- a/src/app/nft-post-page/nft-post/nft-post.component.ts
+++ b/src/app/nft-post-page/nft-post/nft-post.component.ts
@@ -102,6 +102,7 @@ export class NftPostComponent {
   }
 
   refreshPosts() {
+    this.loading = true;
     // Fetch the post entry
     this.getPost().subscribe(
       (res) => {

--- a/src/app/nft-select-serial-number/nft-select-serial-number.component.html
+++ b/src/app/nft-select-serial-number/nft-select-serial-number.component.html
@@ -1,0 +1,52 @@
+<div class="row no-gutters py-15px create-nft-auction-row-border d-flex align-items-center" style="height: 56px">
+  <div class="col-3 mb-0px cursor-pointer" (click)="updateBidSort(SN_FIELD)">
+    Number
+    <i
+      *ngIf="sortByField === SN_FIELD"
+      [ngClass]="sortByOrder === 'asc' ? 'fa-sort-amount-down' : 'fa-sort-amount-up-alt'"
+    ></i>
+  </div>
+  <div class="col-4 mb-0px cursor-pointer" (click)="updateBidSort(HIGH_BID_FIELD)">
+    Highest Bid
+    <i
+      *ngIf="sortByField === HIGH_BID_FIELD"
+      [ngClass]="sortByOrder === 'asc' ? 'fa-sort-amount-down' : 'fa-sort-amount-up-alt'"
+    ></i>
+  </div>
+  <div class="col-5 mb-0px cursor-pointer" (click)="updateBidSort(MIN_BID_FIELD)">
+    Min Bid Amount
+    <i
+      *ngIf="sortByField === MIN_BID_FIELD"
+      [ngClass]="sortByOrder === 'asc' ? 'fa-sort-amount-down' : 'fa-sort-amount-up-alt'"
+    ></i>
+  </div>
+</div>
+<div class="place-bid-rows mb-30px">
+  <div
+    *ngFor="let nft of sortedSerialNumbers"
+    class="row no-gutters background-color-white py-15px mb-0px create-nft-auction-row-border cursor-pointer"
+    (click)="selectSerialNumber(nft.SerialNumber)"
+  >
+    <div class="col-3 mb-0px d-flex align-items-center">
+      <button
+        class="checkbox-circle radio mr-10px ml-10px"
+        [ngClass]="{ checked: selectedSerialNumber?.SerialNumber === nft.SerialNumber }"
+      >
+        <i class="fas fa-check"></i>
+      </button>
+      <span class="lh-15px">#{{ nft.SerialNumber }}</span>
+    </div>
+    <div class="col-4 mb-0px d-flex align-items-center">
+      <div>
+        <div class="d-lg-inline-block d-block">{{ globalVars.nanosToDeSo(nft.HighestBidAmountNanos) }} DESO </div>
+        <div class="text-grey7 d-lg-inline-block d-block">( ~{{globalVars.nanosToUSD(nft.HighestBidAmountNanos, 2) }})</div>
+      </div>
+    </div>
+    <div class="col-5 mb-0px d-flex align-items-center">
+      <div>
+        <div class="d-lg-inline-block d-block">{{ globalVars.nanosToDeSo(nft.MinBidAmountNanos) }} DESO </div>
+        <div class="text-grey7 d-lg-inline-block d-block">(~{{ globalVars.nanosToUSD(nft.MinBidAmountNanos, 2) }})</div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/nft-select-serial-number/nft-select-serial-number.component.ts
+++ b/src/app/nft-select-serial-number/nft-select-serial-number.component.ts
@@ -1,0 +1,47 @@
+import { Component, Input, Output, EventEmitter, OnInit } from "@angular/core";
+import { GlobalVarsService } from "../global-vars.service";
+import { NFTEntryResponse } from "../backend-api.service";
+import * as _ from "lodash";
+
+@Component({
+  selector: "nft-select-serial-number",
+  templateUrl: "./nft-select-serial-number.component.html",
+})
+export class NftSelectSerialNumberComponent implements OnInit {
+  static PAGE_SIZE = 50;
+  static BUFFER_SIZE = 10;
+  static WINDOW_VIEWPORT = false;
+  static PADDING = 0.5;
+
+  @Input() serialNumbers: NFTEntryResponse[];
+  @Output() serialNumberSelected = new EventEmitter<NFTEntryResponse>();
+
+  SN_FIELD = "SerialNumber";
+  HIGH_BID_FIELD = "HighestBidAmountNanos";
+  MIN_BID_FIELD = "MinBidAmountNanos";
+  selectedSerialNumber: NFTEntryResponse = null;
+  sortedSerialNumbers: NFTEntryResponse[];
+  sortByField = this.SN_FIELD;
+  sortByOrder: "desc" | "asc" = "desc";
+
+  constructor(public globalVars: GlobalVarsService) {}
+
+  ngOnInit() {
+    this.updateBidSort(this.SN_FIELD);
+  }
+
+  selectSerialNumber(idx: number) {
+    this.selectedSerialNumber = this.serialNumbers.find((sn) => sn.SerialNumber === idx);
+    this.serialNumberSelected.emit(this.selectedSerialNumber);
+  }
+
+  updateBidSort(sortField: string) {
+    if (this.sortByField === sortField) {
+      this.sortByOrder = this.sortByOrder === "asc" ? "desc" : "asc";
+    } else {
+      this.sortByOrder = "asc";
+    }
+    this.sortByField = sortField;
+    this.sortedSerialNumbers = _.orderBy(this.serialNumbers, [this.sortByField], [this.sortByOrder]);
+  }
+}

--- a/src/app/place-bid-modal/place-bid-modal.component.html
+++ b/src/app/place-bid-modal/place-bid-modal.component.html
@@ -108,7 +108,7 @@
       <div class="d-flex align-items-center mb-15px">
         <button
           class="btn btn-primary font-weight-bold fs-15px br-12px"
-          style="height: 36px; width: 140px; line-height: 15px"
+          style="height: 36px; width: 180px; line-height: 15px"
           (click)="placeBid()"
           [disabled]="placingBids || errors"
         >
@@ -125,40 +125,10 @@
        An NFT can have multiple editions, each with its own unique serial number.
       </div>
       <div class="container fs-15px pb-30px px-0px">
-        <div class="row no-gutters py-15px create-nft-auction-row-border"
-             style="opacity: 50%">
-          <div class="col-2 mb-0px text-align-center">
-            Serial Number
-          </div>
-          <div class="col-5 mb-0px text-align-center">
-            Highest Bid
-          </div>
-          <div class="col-5 mb-0px text-align-center">
-            Min Bid Amount
-          </div>
-        </div>
-        <div style="max-height: 250px; overflow-y: scroll" class="mb-30px">
-          <div #uiScroll *uiScroll="let nft of datasource"
-               class="row no-gutters background-color-white p-15px mb-0px create-nft-auction-row-border cursor-pointer"
-               (click)="selectSerialNumber(nft.SerialNumber)"
-          >
-            <div class="col-2 mb-0px d-flex align-items-center">
-              <span class="lh-15px">#{{nft.SerialNumber}}</span>
-            </div>
-            <div class="col-5 mb-0px d-flex justify-content-around align-items-center">
-              <div>
-                <div class="d-lg-inline-block d-block">{{globalVars.nanosToDeSo(nft.HighestBidAmountNanos)}} DESO </div>
-                <div class="text-grey7 d-lg-inline-block d-block">(~{{globalVars.nanosToUSD(nft.HighestBidAmountNanos, 2)}})</div>
-              </div>
-            </div>
-            <div class="col-5 mb-0px d-flex justify-content-around align-items-center">
-              <div>
-                <div class="d-lg-inline-block d-block">{{ globalVars.nanosToDeSo(nft.MinBidAmountNanos) }} DESO </div>
-                <div class="text-grey7 d-lg-inline-block d-block">(~{{globalVars.nanosToUSD(nft.MinBidAmountNanos, 2)}})</div>
-              </div>
-             </div>
-          </div>
-        </div>
+        <nft-select-serial-number
+          [serialNumbers]="biddableSerialNumbers"
+          (serialNumberSelected)="selectSerialNumber($event)"
+        ></nft-select-serial-number>
       </div>
     </div>
     <div *ngIf="!biddableSerialNumbers.length" class="fs-15px">

--- a/src/app/place-bid-modal/place-bid-modal.component.ts
+++ b/src/app/place-bid-modal/place-bid-modal.component.ts
@@ -142,8 +142,8 @@ export class PlaceBidModalComponent implements OnInit {
     }
   }
 
-  selectSerialNumber(idx: number) {
-    this.selectedSerialNumber = this.availableSerialNumbers.find((sn) => sn.SerialNumber === idx);
+  selectSerialNumber(serialNumber: NFTEntryResponse) {
+    this.selectedSerialNumber = serialNumber;
     this.saveSelection();
   }
 

--- a/src/app/transfer-nft-accept-modal/transfer-nft-accept-modal.component.html
+++ b/src/app/transfer-nft-accept-modal/transfer-nft-accept-modal.component.html
@@ -75,11 +75,10 @@
         class="d-flex align-items-center"
       >
         <button
-          class="primary-button font-weight-bold fs-15px br-12px"
-          style="height: 48px; width: 140px; line-height: 15px"
+          class="btn btn-primary font-weight-bold fs-15px br-12px"
+          style="height: 36px; width: 190px; line-height: 15px"
           (click)="acceptTransfer()"
           [disabled]="acceptingTransfer"
-          [class]="{ 'disabled-button': acceptingTransfer }"
         >
           {{ acceptingTransfer ? "Accepting Transfer" : "Accept Transfer" }}
         </button>

--- a/src/app/transfer-nft-accept-modal/transfer-nft-accept-modal.component.html
+++ b/src/app/transfer-nft-accept-modal/transfer-nft-accept-modal.component.html
@@ -1,0 +1,104 @@
+<div app-theme class="nft-modal-container p-15px">
+  <nft-modal-header [header]="isSelectingSerialNumber ? 'Select an edition' : 'Accept Transfer'" [bsModalRef]="bsModalRef"></nft-modal-header>
+  <simple-center-loader *ngIf="loading"></simple-center-loader>
+  <div *ngIf="!loading">
+    <div *ngIf="transferNFTEntryResponses?.length" [ngClass]="{ 'd-none': isSelectingSerialNumber }">
+      <div class="fs-15px text-grey5">
+        You are about to accept an NFT transferred by @{{ this.transferringUser }}.
+      </div>
+
+      <div *ngIf="!globalVars.isMobile()" class="d-flex justify-content-between nft-modal-bid-details">
+        <div class="col-2 d-flex flex-column m-16px" style="border-right: 1px solid var(--border)">
+          <span>Number</span>
+          <span class="mt-5px">#{{ selectedSerialNumber?.SerialNumber }}</span>
+        </div>
+        <div class="col-5 d-flex flex-column m-16px" style="border-right: 1px solid var(--border)">
+          <span>Highest Bid</span>
+          <span class="mt-5px">{{ globalVars.nanosToDeSo(highBid) }} DESO (~{{globalVars.nanosToUSD(highBid, 2)}})</span>
+        </div>
+        <div class="col-5 d-flex flex-column m-16px">
+          <span>Min Bid Amount</span>
+          <span class="mt-5px">{{ globalVars.nanosToDeSo(selectedSerialNumber?.MinBidAmountNanos) }} DESO (~{{globalVars.nanosToUSD(selectedSerialNumber?.MinBidAmountNanos, 2)}})</span>
+        </div>
+      </div>
+
+      <div *ngIf="globalVars.isMobile()">
+        <div class="nft-modal-bid-details d-flex justify-content-between p-16px">
+          <span class="font-weight-bold">Number</span>
+          <div>
+            <span class="mt-5px">#{{ selectedSerialNumber?.SerialNumber }}</span>
+            <a class="fc-blue ml-16px" (click)="goBackToSerialSelection()">Change</a>
+          </div>
+        </div>
+        <div class="nft-modal-bid-details d-flex flex-column justify-content-center p-16px">
+          <div class="border-bottom pb-10px d-flex justify-content-between">
+            <span class="font-weight-bold">Highest Bid</span>
+            <span>
+              {{ globalVars.nanosToDeSo(highBid) }} DESO (~{{ globalVars.nanosToUSD(highBid, 2) }})
+            </span>
+          </div>
+          <div class="pt-10px d-flex justify-content-between">
+            <span class="font-weight-bold">Min Bid Amount</span>
+            <span>
+              {{ globalVars.nanosToDeSo(selectedSerialNumber?.MinBidAmountNanos) }} DESO (~{{
+                globalVars.nanosToUSD(selectedSerialNumber?.MinBidAmountNanos, 2)
+              }})
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Second separator line -->
+      <div class="py-16px d-flex align-items-center fs-15px text-grey7">
+        <div class="flex-grow-1 nft-modal-separator-2"></div>
+      </div>
+
+      <feed-post
+        [post]="post"
+        [includePaddingOnPost]="true"
+        [isParentPostInThread]="true"
+        [showLeftSelectedBorder]="false"
+        [showInteractionDetails]="false"
+        [contentShouldLinkToThread]="false"
+      ></feed-post>
+
+      <div *ngFor="let error of errors" class="error-container" style="white-space: pre-line;">
+        <i class="fa fa-circle-exclamation"></i>
+        {{ error }}
+      </div>
+      <div
+        [ngClass]="{
+          'floating-bottom-bar': globalVars.isMobile(),
+          'mb-15px': !globalVars.isMobile(),
+          'mt-30px': !globalVars.isMobile()
+        }"
+        class="d-flex align-items-center"
+      >
+        <button
+          class="primary-button font-weight-bold fs-15px br-12px"
+          style="height: 48px; width: 140px; line-height: 15px"
+          (click)="acceptTransfer()"
+          [disabled]="acceptingTransfer"
+          [class]="{ 'disabled-button': acceptingTransfer }"
+        >
+          {{ acceptingTransfer ? "Accepting Transfer" : "Accept Transfer" }}
+        </button>
+      </div>
+
+    </div>
+
+
+    <div *ngIf="transferNFTEntryResponses?.length" [ngClass]="{'d-none': !isSelectingSerialNumber}">
+      <div class="nft-modal__subtitle">An NFT can have multiple editions, each with its own unique serial number.</div>
+      <div class="container fs-15px px-0px">
+        <nft-select-serial-number
+          [serialNumbers]="transferNFTEntryResponses"
+          (serialNumberSelected)="selectSerialNumber($event)"
+        ></nft-select-serial-number>
+      </div>
+    </div>
+    <div *ngIf="!transferNFTEntryResponses.length" class="fs-15px">
+      There are no serial numbers available for you to accept.
+    </div>
+  </div>
+</div>

--- a/src/app/transfer-nft-accept-modal/transfer-nft-accept-modal.component.ts
+++ b/src/app/transfer-nft-accept-modal/transfer-nft-accept-modal.component.ts
@@ -1,0 +1,119 @@
+import { Component, Input, Output, EventEmitter } from "@angular/core";
+import { GlobalVarsService } from "../global-vars.service";
+import { BackendApiService, NFTEntryResponse, PostEntryResponse } from "../backend-api.service";
+import { Router } from "@angular/router";
+import { isNumber } from "lodash";
+import { ToastrService } from "ngx-toastr";
+import { BsModalRef, BsModalService } from "ngx-bootstrap/modal";
+import { Location } from "@angular/common";
+
+@Component({
+  selector: "transfer-nft-accept-modal",
+  templateUrl: "./transfer-nft-accept-modal.component.html",
+})
+export class TransferNftAcceptModalComponent {
+  static PAGE_SIZE = 50;
+  static BUFFER_SIZE = 10;
+  static WINDOW_VIEWPORT = false;
+  static PADDING = 0.5;
+
+  @Input() postHashHex: string;
+  @Input() post: PostEntryResponse;
+  @Input() transferNFTEntryResponses: NFTEntryResponse[];
+  @Output() closeModal = new EventEmitter<any>();
+  @Output() changeTitle = new EventEmitter<string>();
+
+  bidAmountDeSo: number;
+  bidAmountUSD: number;
+  selectedSerialNumber: NFTEntryResponse = null;
+  highBid: number = null;
+  lowBid: number = null;
+  loading = false;
+  isSelectingSerialNumber = true;
+  saveSelectionDisabled = false;
+  showSelectedSerialNumbers = false;
+  acceptingTransfer: boolean = false;
+  errors: string[] = [];
+  minBidCurrency: string = "USD";
+  minBidInput: number = 0;
+  transferringUser: string;
+
+  constructor(
+    public globalVars: GlobalVarsService,
+    private backendApi: BackendApiService,
+    private modalService: BsModalService,
+    private router: Router,
+    private toastr: ToastrService,
+    private location: Location,
+    public bsModalRef: BsModalRef
+  ) {}
+
+  acceptTransfer() {
+    this.saveSelectionDisabled = true;
+    this.acceptingTransfer = true;
+    this.backendApi
+      .AcceptNFTTransfer(
+        this.globalVars.localNode,
+        this.globalVars.loggedInUser.PublicKeyBase58Check,
+        this.post.PostHashHex,
+        this.selectedSerialNumber.SerialNumber,
+        this.globalVars.defaultFeeRateNanosPerKB
+      )
+      .subscribe(
+        (res) => {
+          this.modalService.setDismissReason("transfer accepted");
+          this.bsModalRef.hide();
+          this.toastr.show("Your transfer was completed", null, {
+            toastClass: "info-toast",
+            positionClass: "toast-bottom-center",
+          });
+        },
+        (err) => {
+          console.error(err);
+        }
+      )
+      .add(() => {
+        this.acceptingTransfer = false;
+        this.saveSelectionDisabled = false;
+      });
+  }
+
+  saveSelection(): void {
+    if (!this.saveSelectionDisabled) {
+      this.isSelectingSerialNumber = false;
+      this.showSelectedSerialNumbers = true;
+      this.changeTitle.emit("Confirm Transfer");
+      this.highBid = this.selectedSerialNumber.HighestBidAmountNanos;
+      this.lowBid = this.selectedSerialNumber.LowestBidAmountNanos;
+    }
+  }
+
+  goBackToSerialSelection(): void {
+    this.isSelectingSerialNumber = true;
+    this.showSelectedSerialNumbers = false;
+    this.changeTitle.emit("Choose an edition");
+    this.highBid = null;
+    this.lowBid = null;
+    this.selectedSerialNumber = null;
+  }
+
+  selectSerialNumber(serialNumber: NFTEntryResponse) {
+    this.selectedSerialNumber = serialNumber;
+    this.backendApi
+      .GetSingleProfile(this.globalVars.localNode, this.selectedSerialNumber.LastOwnerPublicKeyBase58Check, "")
+      .subscribe((res) => {
+        if (res && !res.IsBlacklisted) {
+          this.transferringUser = res.Profile?.Username;
+        }
+      });
+    this.saveSelection();
+  }
+
+  bidAmountUSDFormatted() {
+    return isNumber(this.bidAmountUSD) ? `~${this.globalVars.formatUSD(this.bidAmountUSD, 0)}` : "";
+  }
+
+  bidAmountDeSoFormatted() {
+    return isNumber(this.bidAmountDeSo) ? `~${this.bidAmountDeSo.toFixed(2)} $DESO` : "";
+  }
+}

--- a/src/app/transfer-nft-modal/transfer-nft-modal.component.html
+++ b/src/app/transfer-nft-modal/transfer-nft-modal.component.html
@@ -1,0 +1,115 @@
+<div app-theme class="nft-modal-container p-15px">
+  <nft-modal-header [header]="isSelectingSerialNumber ? 'Select an edition' : 'Transfer NFT'" [bsModalRef]="bsModalRef"></nft-modal-header>
+  <simple-center-loader *ngIf="loading"></simple-center-loader>
+  <div *ngIf="!loading">
+    <div *ngIf="transferableSerialNumbers?.length" [ngClass]="{'d-none': isSelectingSerialNumber}">
+      <div class="fs-15px text-grey5">
+        You are about to transfer the NFT shown below.
+      </div>
+
+      <div *ngIf="!globalVars.isMobile()" class="d-flex justify-content-between nft-modal-bid-details">
+          <span class="m-16px">Number #{{ selectedSerialNumber?.SerialNumber }}</span>
+          <a class="fc-blue m-16px" (click)="goBackToSerialSelection()">Change</a>
+      </div>
+
+      <div *ngIf="globalVars.isMobile()">
+        <div class="nft-modal-bid-details d-flex justify-content-between p-16px">
+          <span class="font-weight-bold">Number #{{ selectedSerialNumber?.SerialNumber }}</span>
+          <div>
+            <a class="fc-blue ml-16px" (click)="goBackToSerialSelection()">Change</a>
+          </div>
+        </div>
+      </div>
+
+      <div class="font-weight-semibold mb-10px">
+        Search for a public key or username to whom you want to transfer this NFT
+      </div>
+      <search-bar
+        [isSearchForUsersToSendDESO]="true"
+        [resultsUnderBar]="true"
+        (creatorToMessage)="_selectCreator($event)"
+      ></search-bar>
+      <simple-profile-card
+        [profile]="selectedCreator"
+        [singleColumn]="true"
+        [hideFollowLink]="true"
+        *ngIf="selectedCreator"
+      ></simple-profile-card>
+
+      <div *ngIf="post.HasUnlockable">
+        <div class="fs-15px pt-15px pb-30px text-grey5">
+          This NFT includes unlockable content. Enter it below.
+        </div>
+
+        <textarea
+          class="fs-15px lh-18px br-8px form-control mb-30px"
+          style="width: 100%; padding: 10px"
+          cdkTextareaAutosize
+          cdkAutosizeMinRows="5"
+          [(ngModel)]="unlockableText"
+          #autosize="cdkTextareaAutosize"
+          placeholder="Enter URL, code to redeem, link, etc... "
+        ></textarea>
+      </div>
+
+      <div
+        [ngClass]="{
+          'floating-bottom-bar': globalVars.isMobile(),
+          'mb-15px': !globalVars.isMobile(),
+          'mt-30px': !globalVars.isMobile()
+        }"
+        class="d-flex align-items-center"
+      >
+        <button
+          class="primary-button font-weight-bold fs-15px br-12px"
+          style="height: 48px; width: 140px; line-height: 15px"
+          (click)="transferNFT()"
+          [disabled]="
+            transferringNFT ||
+            !selectedSerialNumber ||
+            !selectedCreator ||
+            (post.HasUnlockable && (unlockableText === null || unlockableText === ''))
+          "
+          [class]="{
+            'disabled-button':
+              transferringNFT ||
+              !selectedSerialNumber ||
+              !selectedCreator ||
+              (post.HasUnlockable && (unlockableText === null || unlockableText === ''))
+          }"
+        >
+          {{ transferringNFT ? "Transferring NFT" : "Transfer NFT" }}
+        </button>
+      </div>
+
+      <!-- Second separator line -->
+      <div class="py-16px d-flex align-items-center fs-15px text-grey7">
+        <div class="flex-grow-1 nft-modal-separator-2"></div>
+      </div>
+
+      <feed-post
+        [post]="post"
+        [includePaddingOnPost]="true"
+        [isParentPostInThread]="true"
+        [showLeftSelectedBorder]="false"
+        [showInteractionDetails]="false"
+        [contentShouldLinkToThread]="false"
+      ></feed-post>
+
+    </div>
+
+
+    <div *ngIf="transferableSerialNumbers?.length" [ngClass]="{'d-none': !isSelectingSerialNumber}">
+      <div class="nft-modal__subtitle">These are the serial numbers that are transferable</div>
+      <div class="container fs-15px px-0px">
+        <nft-select-serial-number
+          [serialNumbers]="transferableSerialNumbers"
+          (serialNumberSelected)="selectSerialNumber($event)"
+        ></nft-select-serial-number>
+      </div>
+    </div>
+    <div *ngIf="!transferableSerialNumbers.length" class="fs-15px">
+      There are no serial numbers available for you to transfer.
+    </div>
+  </div>
+</div>

--- a/src/app/transfer-nft-modal/transfer-nft-modal.component.html
+++ b/src/app/transfer-nft-modal/transfer-nft-modal.component.html
@@ -61,8 +61,8 @@
         class="d-flex align-items-center"
       >
         <button
-          class="primary-button font-weight-bold fs-15px br-12px"
-          style="height: 48px; width: 140px; line-height: 15px"
+          class="btn btn-primary font-weight-bold fs-15px br-12px"
+          style="height: 36px; width: 180px; line-height: 15px"
           (click)="transferNFT()"
           [disabled]="
             transferringNFT ||
@@ -70,13 +70,6 @@
             !selectedCreator ||
             (post.HasUnlockable && (unlockableText === null || unlockableText === ''))
           "
-          [class]="{
-            'disabled-button':
-              transferringNFT ||
-              !selectedSerialNumber ||
-              !selectedCreator ||
-              (post.HasUnlockable && (unlockableText === null || unlockableText === ''))
-          }"
         >
           {{ transferringNFT ? "Transferring NFT" : "Transfer NFT" }}
         </button>

--- a/src/app/transfer-nft-modal/transfer-nft-modal.component.ts
+++ b/src/app/transfer-nft-modal/transfer-nft-modal.component.ts
@@ -1,0 +1,188 @@
+import { Component, OnInit, Input, Output, EventEmitter } from "@angular/core";
+import { GlobalVarsService } from "../global-vars.service";
+import { BackendApiService, NFTEntryResponse, PostEntryResponse, ProfileEntryResponse } from "../backend-api.service";
+import { orderBy } from "lodash";
+import { Router } from "@angular/router";
+import { ToastrService } from "ngx-toastr";
+import { BsModalRef, BsModalService } from "ngx-bootstrap/modal";
+import { Location } from "@angular/common";
+import { SwalHelper } from "../../lib/helpers/swal-helper";
+
+@Component({
+  selector: "transfer-nft-modal",
+  templateUrl: "./transfer-nft-modal.component.html",
+})
+export class TransferNftModalComponent implements OnInit {
+  static PAGE_SIZE = 50;
+  static BUFFER_SIZE = 10;
+  static WINDOW_VIEWPORT = false;
+  static PADDING = 0.5;
+
+  @Input() postHashHex: string;
+  @Input() post: PostEntryResponse;
+  @Output() closeModal = new EventEmitter<any>();
+  @Output() changeTitle = new EventEmitter<string>();
+
+  selectedSerialNumber: NFTEntryResponse = null;
+  loading = true;
+  transferringNFT: boolean = false;
+  isSelectingSerialNumber = true;
+  saveSelectionDisabled = false;
+  showSelectedSerialNumbers = false;
+  transferableSerialNumbers: NFTEntryResponse[];
+  SN_FIELD = "SerialNumber";
+  LAST_PRICE_FIELD = "LastAcceptedBidAmountNanos";
+  sortByField = this.SN_FIELD;
+  sortByOrder: "desc" | "asc" = "asc";
+  selectedCreator: ProfileEntryResponse;
+  unlockableText: string = "";
+
+  constructor(
+    public globalVars: GlobalVarsService,
+    private backendApi: BackendApiService,
+    private modalService: BsModalService,
+    private router: Router,
+    private toastr: ToastrService,
+    private location: Location,
+    public bsModalRef: BsModalRef
+  ) {}
+
+  ngOnInit(): void {
+    this.backendApi
+      .GetNFTEntriesForNFTPost(
+        this.globalVars.localNode,
+        this.globalVars.loggedInUser.PublicKeyBase58Check,
+        this.post.PostHashHex
+      )
+      .subscribe((res) => {
+        this.transferableSerialNumbers = orderBy(
+          (res.NFTEntryResponses as NFTEntryResponse[]).filter(
+            (nftEntryResponse) =>
+              nftEntryResponse.OwnerPublicKeyBase58Check === this.globalVars.loggedInUser?.PublicKeyBase58Check &&
+              !nftEntryResponse.IsPending &&
+              !nftEntryResponse.IsForSale
+          ),
+          [this.sortByField],
+          [this.sortByOrder]
+        );
+      })
+      .add(() => (this.loading = false));
+  }
+
+  transferNFT() {
+    this.saveSelectionDisabled = true;
+    this.transferringNFT = true;
+    SwalHelper.fire({
+      target: this.globalVars.getTargetComponentSelector(),
+      title: "Transfer NFT",
+      html: `You are about to transfer this NFT to ${
+        this.selectedCreator?.Username || this.selectedCreator?.PublicKeyBase58Check
+      }`,
+      showConfirmButton: true,
+      showCancelButton: true,
+      reverseButtons: true,
+      customClass: {
+        confirmButton: "btn btn-light",
+        cancelButton: "btn btn-light no",
+      },
+      confirmButtonText: "Ok",
+      cancelButtonText: "Cancel",
+    }).then((res) => {
+      if (res.isConfirmed) {
+        this.backendApi
+          .TransferNFT(
+            this.globalVars.localNode,
+            this.globalVars.loggedInUser?.PublicKeyBase58Check,
+            this.selectedCreator?.PublicKeyBase58Check,
+            this.post.PostHashHex,
+            this.selectedSerialNumber?.SerialNumber,
+            this.unlockableText,
+            this.globalVars.defaultFeeRateNanosPerKB
+          )
+          .subscribe(
+            (res) => {
+              this.modalService.setDismissReason("nft transferred");
+              this.bsModalRef.hide();
+              this.showToast();
+            },
+            (err) => {
+              console.error(err);
+              this.globalVars._alertError(this.backendApi.parseMessageError(err));
+            }
+          )
+          .add(() => {
+            this.transferringNFT = false;
+            this.saveSelectionDisabled = false;
+          });
+      } else {
+        this.transferringNFT = false;
+        this.saveSelectionDisabled = false;
+      }
+    });
+  }
+
+  showToast(): void {
+    const link = `/${this.globalVars.RouteNames.NFT}/${this.post.PostHashHex}`;
+    this.toastr.show(`NFT Transferred<a href="${link}" class="toast-link cursor-pointer">View</a>`, null, {
+      toastClass: "info-toast",
+      enableHtml: true,
+      positionClass: "toast-bottom-center",
+    });
+  }
+
+  saveSelection(): void {
+    if (!this.saveSelectionDisabled) {
+      this.isSelectingSerialNumber = false;
+      this.showSelectedSerialNumbers = true;
+      this.changeTitle.emit("Transfer NFT");
+    }
+  }
+
+  goBackToSerialSelection(): void {
+    this.isSelectingSerialNumber = true;
+    this.showSelectedSerialNumbers = false;
+    this.changeTitle.emit("Choose an edition");
+    this.selectedSerialNumber = null;
+  }
+
+  selectSerialNumber(serialNumber: NFTEntryResponse) {
+    this.selectedSerialNumber = serialNumber;
+    this.saveSelection();
+  }
+
+  deselectSerialNumber() {
+    if (this.transferringNFT) {
+      return;
+    }
+    this.selectedSerialNumber = null;
+    this.showSelectedSerialNumbers = false;
+  }
+
+  lastPage = null;
+
+  getPage(page: number) {
+    if (this.lastPage != null && page > this.lastPage) {
+      return [];
+    }
+    const startIdx = page * TransferNftModalComponent.PAGE_SIZE;
+    const endIdx = (page + 1) * TransferNftModalComponent.PAGE_SIZE;
+
+    return new Promise((resolve, reject) => {
+      resolve(this.transferableSerialNumbers.slice(startIdx, Math.min(endIdx, this.transferableSerialNumbers.length)));
+    });
+  }
+
+  updateSort(sortField: string) {
+    if (this.sortByField === sortField) {
+      this.sortByOrder = this.sortByOrder === "asc" ? "desc" : "asc";
+    } else {
+      this.sortByOrder = "asc";
+    }
+    this.sortByField = sortField;
+    this.transferableSerialNumbers = orderBy(this.transferableSerialNumbers, [this.sortByField], [this.sortByOrder]);
+  }
+
+  _selectCreator(selectedCreator: ProfileEntryResponse) {
+    this.selectedCreator = selectedCreator;
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2831,3 +2831,31 @@ input {
 .referral-link-info__blue-border {
   border-left: 5px solid $buy-button-blue !important;
 }
+
+.checkbox-circle {
+  i {
+    display: none;
+    position: relative;
+    top: -5px;
+  }
+  padding: 3px;
+  width: 22px;
+  height: 22px;
+  border: 1px solid var(--border);
+  border-radius: 100%;
+  background: none;
+  transition: background-color .5s;
+  &.radio {
+    transition: background-color 0s;
+  }
+  &.checked {
+    background: var(--highlight);
+    i {
+      display: inline;
+      color: var(--tile-bg);
+    }
+    &.radio {
+      transition: background-color .5s;
+    }
+  }
+}


### PR DESCRIPTION
What's been done:
1. Add modals for transfer NFT, burn NFT, and accept NFT transfer
2. Show "Pending" in the Owners table if owner has not accepted transfer yet
3. Update NFTs view on user's profile to have Transferrable and Pending Transfers views.
4. Make re-usable serial number selector
5. Update close modal listeners

Pending owner text
![image](https://user-images.githubusercontent.com/81658138/147981229-12853463-d3cf-42c5-b8a7-04334cdde628.png)

Feed post dropdown updates
![image](https://user-images.githubusercontent.com/81658138/147981262-905108f9-5ed4-4960-b6fb-d4848aef936f.png)

Pending Transfer View
![image](https://user-images.githubusercontent.com/81658138/147981590-c8788290-2fb3-47b8-a2f9-e2fc7d625e76.png)

Transferrable View
![image](https://user-images.githubusercontent.com/81658138/147981614-a7b5cac3-1c44-4e66-9cdd-c2ec1f5dc54c.png)


Transfer NFT Modal
![image](https://user-images.githubusercontent.com/81658138/147981519-7cb7c7cf-2df6-4366-92b4-7b75c5ebaebd.png)

Burn NFT modal
![image](https://user-images.githubusercontent.com/81658138/147981545-5a75ecc1-72ae-4a05-80cb-9118886ecd47.png)

Accept Transfer Modal
![image](https://user-images.githubusercontent.com/81658138/147981743-dec4f550-a6c4-4664-babe-95db7ead863a.png)
