### PR TITLE
Fix blank screen on safari desktop with small window size

### DIFF
--- a/src/app/global-vars.service.ts
+++ b/src/app/global-vars.service.ts
@@ -522,7 +522,10 @@ export class GlobalVarsService {
     // from https://stackoverflow.com/questions/1248081/how-to-get-the-browser-viewport-dimensions
     const viewportWidth = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0);
 
-    return viewportWidth <= 992;
+    //Safari has this weird issue where it causes a blank screen around 991 & 977 pixels - this 15px increase seems to resolve this
+    //FIXME: Better solution may be in the CSS media queries
+    var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+    return isSafari ? viewportWidth <= 1007 : viewportWidth <= 992;
   }
 
   // Calculates the amount of deso one would receive if they sold an amount equal to creatorCoinAmountNano


### PR DESCRIPTION
On desktop (macOs) safari shows blank screen around 991 - 977 pixels.

![CleanShot 2022-01-19 at 16 08 48](https://user-images.githubusercontent.com/69529928/150170616-9ec2cc73-c4a7-4b67-b293-a8b0ece48eca.gif)

This was the simplest fix I could come up with. Better approach maybe in CSS - but problem is difference between browsers on whether the scrollbar is counted.

@superzordon let me know if you want me to PR this to diamondapp as well.