### PR TITLE
Posts/Users pages are blank when user not logged in

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -114,7 +114,7 @@ export class AppComponent implements OnInit {
 
     return zip(
       this.backendApi.GetUsersStateless(this.globalVars.localNode, [loggedInUserPublicKey], false),
-      environment.verificationEndpointHostname && loggedInUserPublicKey
+      environment.verificationEndpointHostname && !_.isNil(loggedInUserPublicKey)
         ? this.backendApi.GetUserMetadata(environment.verificationEndpointHostname, loggedInUserPublicKey).pipe(
             catchError((err) => {
               console.error(err);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -114,7 +114,7 @@ export class AppComponent implements OnInit {
 
     return zip(
       this.backendApi.GetUsersStateless(this.globalVars.localNode, [loggedInUserPublicKey], false),
-      environment.verificationEndpointHostname
+      environment.verificationEndpointHostname && loggedInUserPublicKey
         ? this.backendApi.GetUserMetadata(environment.verificationEndpointHostname, loggedInUserPublicKey).pipe(
             catchError((err) => {
               console.error(err);


### PR DESCRIPTION
Issue: When a visitor hits a /posts/ or /u/ subpage but is not logged in - nothing shows. 
Expected: show post content / user profile page even when user not logged in.
Cause: Requesting metadata of undefined causes error.

<img width="983" alt="CleanShot 2022-02-03 at 09 44 46@2x" src="https://user-images.githubusercontent.com/69529928/152322605-dc966b5c-e737-4d8d-aab1-ef34e840fd35.png">

This additional checks makes sure verification / node.deso.org metadata is only requested if loggedInUserPublicKey is ok.