### PR TITLE
Use local storage to determine max post length

### DIFF
--- a/src/app/backend-api.service.ts
+++ b/src/app/backend-api.service.ts
@@ -505,6 +505,9 @@ export class BackendApiService {
   // Messaging V3 default key name.
   DefaultKey = "default-key";
 
+  // Store the maximum characters allowed per post in localStorage
+  MaxPostLength = "maxPostLength";
+
   // TODO: Wipe all this data when transition is complete
   LegacyUserListKey = "userList";
   LegacySeedListKey = "seedList";

--- a/src/app/feed/feed-create-post/feed-create-post.component.html
+++ b/src/app/feed/feed-create-post/feed-create-post.component.html
@@ -112,7 +112,7 @@
       'fc-red': characterCountExceedsMaxLength()
     }"
   >
-    {{ postInput.length }} / {{ GlobalVarsService.MAX_POST_LENGTH }}
+    {{ postInput.length }} / {{ maxPostLength }}
   </span>
   <i
     class="fas fa-code fa-lg text-grey8A cursor-pointer fs-18px pr-15px"

--- a/src/app/feed/feed-create-post/feed-create-post.component.ts
+++ b/src/app/feed/feed-create-post/feed-create-post.component.ts
@@ -66,6 +66,8 @@ export class FeedCreatePostComponent implements OnInit {
   videoStreamInterval: Timer = null;
   readyToStream: boolean = false;
 
+  maxPostLength: number;
+
   // Emits a PostEntryResponse. It would be better if this were typed.
   @Output() postCreated = new EventEmitter();
 
@@ -89,6 +91,7 @@ export class FeedCreatePostComponent implements OnInit {
     if (this.inTutorial) {
       this.postInput = "It's time to DESO!";
     }
+    this.maxPostLength = this.backendApi.GetStorage(this.backendApi.MaxPostLength);
   }
 
   onPaste(event: any): void {
@@ -117,12 +120,12 @@ export class FeedCreatePostComponent implements OnInit {
   showCharacterCountWarning() {
     return (
       this.postInput.length >= FeedCreatePostComponent.SHOW_POST_LENGTH_WARNING_THRESHOLD &&
-      this.postInput.length <= GlobalVarsService.MAX_POST_LENGTH
+      this.postInput.length <= this.maxPostLength
     );
   }
 
   characterCountExceedsMaxLength() {
-    return this.postInput.length > GlobalVarsService.MAX_POST_LENGTH;
+    return this.postInput.length > this.maxPostLength;
   }
 
   getPlaceholderText() {
@@ -146,7 +149,7 @@ export class FeedCreatePostComponent implements OnInit {
   }
 
   submitPost() {
-    if (this.postInput.length > GlobalVarsService.MAX_POST_LENGTH) {
+    if (this.postInput.length > this.maxPostLength) {
       return;
     }
 

--- a/src/app/global-vars.service.ts
+++ b/src/app/global-vars.service.ts
@@ -65,7 +65,7 @@ export class GlobalVarsService {
     private httpClient: HttpClient
   ) {}
 
-  static MAX_POST_LENGTH = 560;
+  static DEFAULT_MAX_POST_LENGTH = 560;
 
   static FOUNDER_REWARD_BASIS_POINTS_WARNING_THRESHOLD = 50 * 100;
 
@@ -944,6 +944,11 @@ export class GlobalVarsService {
     this.identityService.sanitizedIdentityServiceURL = this.sanitizer.bypassSecurityTrustResourceUrl(
       `${identityServiceURL}/embed?v=2`
     );
+
+    const maxPostLength = this.backendApi.GetStorage(this.backendApi.MaxPostLength);
+    if (!maxPostLength) {
+      this.backendApi.SetStorage(this.backendApi.MaxPostLength, GlobalVarsService.DEFAULT_MAX_POST_LENGTH);
+    }
 
     this._globopoll(() => {
       if (!this.defaultFeeRateNanosPerKB) {


### PR DESCRIPTION
Instead of hardcoding the maximum post length, this change stores and reads the limit from local storage.

The benefit is that it serves the power user while changing nothing for the average user. Many users go to alternative nodes _just_ to post longer. This skews the node source metrics and interrupts the user flow unnecessarily.

For context, with BitClout+ I must completely replace the submit-post transaction handling in order to increase the max length. This is undesirable for many reasons, including it's tendency to break when any post-related changes are made to frontend.

I didn't set an upper technical limit, but perhaps there should be one hardcoded that tells the user they've set the limit too high? I believe this limit is determined by the maximum transaction size; is that correct? I've tested as many as 15k characters without issue, and was told the transaction size limit is 20kb. 