### PR TITLE
Added # (number sign) support for parsing Mousai links

### DIFF
--- a/src/lib/services/embed-url-parser-service/embed-url-parser-service.spec.ts
+++ b/src/lib/services/embed-url-parser-service/embed-url-parser-service.spec.ts
@@ -35,6 +35,7 @@ describe("EmbedUrlParserService", () => {
     album: `album/1000/artist-name/album-name`,
     playlist: `playlist/1000/playlist-name`,
     track: `track/1000/track-name`,
+    trackContainingNumberSign: `track/1000/track-#6`,
   };
   const createValidMousaiURLFromPath = (path: string) => [
     `https://mousai.stream/${path}`,
@@ -46,11 +47,13 @@ describe("EmbedUrlParserService", () => {
     ...createValidMousaiURLFromPath(mousaiPaths.album),
     ...createValidMousaiURLFromPath(mousaiPaths.playlist),
     ...createValidMousaiURLFromPath(mousaiPaths.track),
+    ...createValidMousaiURLFromPath(mousaiPaths.trackContainingNumberSign),
   ];
   const validMousaiEmbedURLs = [
     `https://mousai.stream/${mousaiPaths.album}/embed`,
     `https://mousai.stream/${mousaiPaths.playlist}/embed`,
     `https://mousai.stream/${mousaiPaths.track}/embed`,
+    `https://mousai.stream/${mousaiPaths.trackContainingNumberSign}/embed`,
   ];
 
   const vimeoVideoID = "310195153";

--- a/src/lib/services/embed-url-parser-service/embed-url-parser-service.ts
+++ b/src/lib/services/embed-url-parser-service/embed-url-parser-service.ts
@@ -22,7 +22,7 @@ export class EmbedUrlParserService {
   }
 
   static mousaiParser(url): string | boolean {
-    const regExp = /^.*mousai\.stream\/((album|playlist|track)\/[0-9]+(\/[a-z0-9-_,]+){1,2}?)(?=(\/embed|$))/;
+    const regExp = /^.*mousai\.stream\/((album|playlist|track)\/[0-9]+(\/[a-z0-9-_,#]+){1,2}?)(?=(\/embed|$))/;
     const match = url.match(regExp);
     return match ? match[1] : false;
   }
@@ -347,7 +347,7 @@ export class EmbedUrlParserService {
   }
 
   static isValidMousaiEmbedURL(link: string): boolean {
-    const regExp = /https:\/\/mousai\.stream\/((album|playlist|track)\/[0-9]+(\/[a-z0-9-_,]+){1,2}?)\/embed$/;
+    const regExp = /https:\/\/mousai\.stream\/((album|playlist|track)\/[0-9]+(\/[a-z0-9-_,#]+){1,2}?)\/embed$/;
     return !!link.match(regExp);
   }
 


### PR DESCRIPTION
The following PR introduces support for # (number sign) while embedding URLs from Mousai.
An example link that should be supported by this PR is [https://mousai.stream/track/11739/creatiers-#6](https://mousai.stream/track/11739/creatiers-#6)