### PR TITLE
Fix gitpod node/npm version

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,8 @@
+FROM gitpod/workspace-full:latest
+
+RUN bash -c 'NODE_VERSION="14.15.5" \
+    && source $HOME/.nvm/nvm.sh && nvm install $NODE_VERSION \
+    && nvm use $NODE_VERSION && nvm alias default $NODE_VERSION \
+    && npm -g install npm@7'
+
+RUN echo "nvm use default &>/dev/null" >> ~/.bashrc.d/51-nvm-fix

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,7 @@
+# Use custom node & npm versions in image
+image:
+  file: .gitpod.Dockerfile
+
 # Commands to start on workspace startup
 tasks:
   - name: open terminial

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This frontend works best with Node v14.15.5 and Npm v7. If you cant use these ve
 
 # Start Coding
 
-The quickest way to contribute changes to the Deso Frontend is the following these steps:
+The quickest way to contribute changes to the DeSo Frontend is the following these steps:
 
 1. Open frontend repo in Gitpod
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,13 @@ docs should give you everything you need to get started:
 - [Setting Up Your Dev Environment](https://docs.deso.org/code/dev-setup)
 - [Making Your First Changes](https://docs.deso.org/code/making-your-first-changes)
 
+# Node / NPM versions
+
+This frontend works best with Node v14.15.5 and Npm v7. If you cant use these versions, then try `npm install --force`.
+
 # Start Coding
 
-The quickest way to contribute changes to the BitClout Frontend is the following these steps:
+The quickest way to contribute changes to the Deso Frontend is the following these steps:
 
 1. Open frontend repo in Gitpod
 


### PR DESCRIPTION
See [post with history on deso here](https://diamondapp.com/posts/a1abdb76f68980f7dd3214c185b3e5489be9ff2eafb9feea2b58ac7a9a425868)

Prior to the April commit - the gitpod button would launch frontend repo fine in gitpod. But since lockfile was switched to v2 - this broke.

This PR fixes that by customising the docker build used by gitpod and installing node 14.15.5 and npm 7.

@DeSoDog @lazynina 