### PR TITLE
Add encryptedMesssagingKeyRandomness to payload

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -114,8 +114,8 @@ export class AppComponent implements OnInit {
 
     // If we recently added a new public key, log in the user and clear the value
     if (this.identityService.identityServicePublicKeyAdded) {
-      loggedInUserPublicKey = this.identityService
-        .identityServicePublicKeyAdded;
+      loggedInUserPublicKey =
+        this.identityService.identityServicePublicKeyAdded;
       this.identityService.identityServicePublicKeyAdded = null;
     }
 
@@ -394,6 +394,7 @@ export class AppComponent implements OnInit {
   loadApp() {
     this.identityService.identityServiceUsers =
       this.backendApi.GetStorage(this.backendApi.IdentityUsersKey) || {};
+
     // Filter out invalid public keys
     const publicKeys = Object.keys(this.identityService.identityServiceUsers);
     for (const publicKey of publicKeys) {

--- a/src/app/backend-api.service.ts
+++ b/src/app/backend-api.service.ts
@@ -634,6 +634,20 @@ export class BackendApiService {
     return JSON.parse(data);
   }
 
+  SetEncryptedMessagingKeyRandomnessForPublicKey(
+    publicKeyBase58Check: string,
+    encryptedMessagingKeyRandomness: string
+  ): void {
+    const users = this.GetStorage(this.IdentityUsersKey);
+    this.setIdentityServiceUsers({
+      ...users,
+      [publicKeyBase58Check]: {
+        ...users[publicKeyBase58Check],
+        encryptedMessagingKeyRandomness,
+      },
+    });
+  }
+
   // Assemble a URL to hit the BE with.
   _makeRequestURL(
     endpoint: string,
@@ -1046,15 +1060,10 @@ export class BackendApiService {
                       'Error getting encrypted messaging key randomness'
                     );
                   }
-                  const users = this.GetStorage(this.IdentityUsersKey);
-                  this.setIdentityServiceUsers({
-                    ...users,
-                    [SenderPublicKeyBase58Check]: {
-                      ...users[SenderPublicKeyBase58Check],
-                      encryptedMessagingKeyRandomness:
-                        res.encryptedMessagingKeyRandomness,
-                    },
-                  });
+                  this.SetEncryptedMessagingKeyRandomnessForPublicKey(
+                    SenderPublicKeyBase58Check,
+                    res.encryptedMessagingKeyRandomness
+                  );
                   return this.GetDefaultKey(
                     endpoint,
                     SenderPublicKeyBase58Check
@@ -2066,21 +2075,15 @@ export class BackendApiService {
                   true
                 ) {
                   // go get the key
-                  debugger;
                   return launchDefaultMessagingKey$().pipe(
                     switchMap((defaultMessagingKeyResponse) => {
                       if (
                         defaultMessagingKeyResponse.encryptedMessagingKeyRandomness
                       ) {
-                        const users = this.GetStorage(this.IdentityUsersKey);
-                        this.setIdentityServiceUsers({
-                          ...users,
-                          [PublicKeyBase58Check]: {
-                            ...users[PublicKeyBase58Check],
-                            encryptedMessagingKeyRandomness:
-                              defaultMessagingKeyResponse.encryptedMessagingKeyRandomness,
-                          },
-                        });
+                        this.SetEncryptedMessagingKeyRandomnessForPublicKey(
+                          PublicKeyBase58Check,
+                          defaultMessagingKeyResponse.encryptedMessagingKeyRandomness
+                        );
                         return this.GetDefaultKey(
                           endpoint,
                           PublicKeyBase58Check

--- a/src/app/backend-api.service.ts
+++ b/src/app/backend-api.service.ts
@@ -956,16 +956,19 @@ export class BackendApiService {
         switchMap((partyMessagingKeys) => {
           // Once we determine the messaging keys of the parties, we will then encrypt a message based on the keys.
           const callEncrypt$ = (encryptedMessagingKeyRandomness?: string) => {
-            return this.identityService.encrypt({
+            let payload = {
               ...this.identityService.identityServiceParamsForKey(
                 SenderPublicKeyBase58Check
               ),
-              encryptedMessagingKeyRandomness,
               recipientPublicKey:
                 partyMessagingKeys.RecipientMessagingPublicKeyBase58Check,
               senderGroupKeyName: partyMessagingKeys.SenderMessagingKeyName,
               message: MessageText,
-            });
+            };
+            if (encryptedMessagingKeyRandomness) {
+              payload = { ...payload, encryptedMessagingKeyRandomness };
+            }
+            return this.identityService.encrypt(payload);
           };
 
           const callRegisterGroupMessagingKey$ = (res: {

--- a/src/app/backend-api.service.ts
+++ b/src/app/backend-api.service.ts
@@ -2066,6 +2066,7 @@ export class BackendApiService {
                   true
                 ) {
                   // go get the key
+                  debugger;
                   return launchDefaultMessagingKey$().pipe(
                     switchMap((defaultMessagingKeyResponse) => {
                       if (
@@ -2077,7 +2078,7 @@ export class BackendApiService {
                           [PublicKeyBase58Check]: {
                             ...users[PublicKeyBase58Check],
                             encryptedMessagingKeyRandomness:
-                              res.encryptedMessagingKeyRandomness,
+                              defaultMessagingKeyResponse.encryptedMessagingKeyRandomness,
                           },
                         });
                         return this.GetDefaultKey(

--- a/src/app/backend-api.service.ts
+++ b/src/app/backend-api.service.ts
@@ -952,6 +952,7 @@ export class BackendApiService {
     ).pipe(
       switchMap((partyMessagingKeys) => {
         // Once we determine the messaging keys of the parties, we will then encrypt a message based on the keys.
+
         return this.identityService
           .encrypt({
             ...this.identityService.identityServiceParamsForKey(
@@ -1945,7 +1946,10 @@ export class BackendApiService {
     });
   }
 
-  GetDefaultKey(endpoint: string, publicKeyBase58Check: string): Observable<MessagingGroupEntryResponse | null> {
+  GetDefaultKey(
+    endpoint: string,
+    publicKeyBase58Check: string
+  ): Observable<MessagingGroupEntryResponse | null> {
     return this.GetAllMessagingGroupKeys(endpoint, publicKeyBase58Check).pipe(
       map((res) => {
         const defaultKeys = res.MessagingGroupEntries.filter(

--- a/src/app/global-vars.service.ts
+++ b/src/app/global-vars.service.ts
@@ -304,7 +304,7 @@ export class GlobalVarsService {
         this.messagesRequestsFollowersOnly,
         this.messagesRequestsFollowedOnly,
         this.messagesSortAlgorithm,
-        this.feeRateDeSoPerKB * 1e9,
+        this.feeRateDeSoPerKB * 1e9
       )
       .subscribe(
         (res) => {

--- a/src/app/global-vars.service.ts
+++ b/src/app/global-vars.service.ts
@@ -2,7 +2,8 @@ import { Injectable } from '@angular/core';
 import {
   BackendApiService,
   BalanceEntryResponse,
-  DeSoNode, MessagingGroupEntryResponse,
+  DeSoNode,
+  MessagingGroupEntryResponse,
   PostEntryResponse,
   TransactionFee,
   TutorialStatus,
@@ -151,7 +152,8 @@ export class GlobalVarsService {
   // and make everything use sockets.
   updateEverything: any;
 
-  emailRegExp = /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/;
+  emailRegExp =
+    /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/;
 
   latestBitcoinAPIResponse: any;
 
@@ -301,7 +303,8 @@ export class GlobalVarsService {
         this.messagesRequestsHoldingsOnly,
         this.messagesRequestsFollowersOnly,
         this.messagesRequestsFollowedOnly,
-        this.messagesSortAlgorithm
+        this.messagesSortAlgorithm,
+        this.feeRateDeSoPerKB * 1e9,
       )
       .subscribe(
         (res) => {
@@ -391,10 +394,8 @@ export class GlobalVarsService {
   }
 
   getLoggedInUserDefaultKey() {
-    this.backendApi.GetDefaultKey(
-      this.localNode,
-      this.loggedInUser.PublicKeyBase58Check
-    )
+    this.backendApi
+      .GetDefaultKey(this.localNode, this.loggedInUser.PublicKeyBase58Check)
       .subscribe((res) => {
         if (!res) {
           SwalHelper.fire({
@@ -428,7 +429,8 @@ export class GlobalVarsService {
                               this.loggedInUser.PublicKeyBase58Check
                             )
                             .subscribe((messagingGroupEntryResponse) => {
-                              this.loggedInUserDefaultKey = messagingGroupEntryResponse;
+                              this.loggedInUserDefaultKey =
+                                messagingGroupEntryResponse;
                             });
                         }
                       });
@@ -1143,10 +1145,8 @@ export class GlobalVarsService {
       );
       bithuntService.getCommunityProjectsLeaderboard().subscribe((res) => {
         this.allCommunityProjectsLeaderboard = res;
-        this.topCommunityProjectsLeaderboard = this.allCommunityProjectsLeaderboard.slice(
-          0,
-          10
-        );
+        this.topCommunityProjectsLeaderboard =
+          this.allCommunityProjectsLeaderboard.slice(0, 10);
       });
     }
 
@@ -1262,8 +1262,7 @@ export class GlobalVarsService {
     Swal.fire({
       target: this.getTargetComponentSelector(),
       title: 'Congrats!',
-      html:
-        "You just got some free money!<br><br><b>Now it's time to learn how to earn even more!</b>",
+      html: "You just got some free money!<br><br><b>Now it's time to learn how to earn even more!</b>",
       showConfirmButton: true,
       // Only show skip option to admins
       showCancelButton: !!this.loggedInUser?.IsAdmin,

--- a/src/app/global-vars.service.ts
+++ b/src/app/global-vars.service.ts
@@ -410,6 +410,10 @@ export class GlobalVarsService {
                 )
                 .subscribe((res) => {
                   if (res) {
+                    this.backendApi.SetEncryptedMessagingKeyRandomnessForPublicKey(
+                      this.loggedInUser.PublicKeyBase58Check,
+                      res.encryptedMessagingKeyRandomness
+                    );
                     this.backendApi
                       .RegisterGroupMessagingKey(
                         this.localNode,

--- a/src/app/identity.service.ts
+++ b/src/app/identity.service.ts
@@ -15,6 +15,7 @@ export type IdentityMessagingResponse = {
   encryptedToMembersGroupMessagingPrivateKey: string[];
   messagingKeySignature: string;
   messagingPublicKeyBase58Check: string;
+  encryptedMessagingKeyRandomness: string | undefined;
 };
 
 @Injectable({
@@ -217,6 +218,8 @@ export class IdentityService {
     encryptedSeedHex: string;
     senderGroupKeyName: string;
     recipientPublicKey: string;
+    encryptedMessagingKeyRandomness: string | undefined;
+    derivedPublicKeyBase58Check: string | undefined;
     message: string;
   }): Observable<any> {
     return this.send('encrypt', payload);
@@ -227,6 +230,9 @@ export class IdentityService {
     accessLevelHmac: string;
     encryptedSeedHex: string;
     encryptedMessages: any;
+    derivedPublicKeyBase58Check: string | undefined;
+    ownerPublicKeyBase58Check: string;
+    encryptedMessagingKeyRandomness: string | undefined;
   }): Observable<any> {
     return this.send('decrypt', payload);
   }

--- a/src/app/identity.service.ts
+++ b/src/app/identity.service.ts
@@ -254,9 +254,18 @@ export class IdentityService {
   // Helpers
 
   identityServiceParamsForKey(publicKey: string) {
-    const { encryptedSeedHex, accessLevel, accessLevelHmac } =
-      this.identityServiceUsers[publicKey];
-    return { encryptedSeedHex, accessLevel, accessLevelHmac };
+    const {
+      encryptedSeedHex,
+      accessLevel,
+      accessLevelHmac,
+      encryptedMessagingKeyRandomness,
+    } = this.identityServiceUsers[publicKey];
+    return {
+      encryptedSeedHex,
+      accessLevel,
+      accessLevelHmac,
+      encryptedMessagingKeyRandomness,
+    };
   }
 
   // Incoming messages

--- a/src/app/identity.service.ts
+++ b/src/app/identity.service.ts
@@ -259,12 +259,15 @@ export class IdentityService {
       accessLevel,
       accessLevelHmac,
       encryptedMessagingKeyRandomness,
+      derivedPublicKeyBase58Check,
     } = this.identityServiceUsers[publicKey];
     return {
       encryptedSeedHex,
       accessLevel,
       accessLevelHmac,
       encryptedMessagingKeyRandomness,
+      ownerPublicKeyBase58Check: publicKey,
+      derivedPublicKeyBase58Check,
     };
   }
 

--- a/src/app/messages-page/messages-inbox/messages-inbox.component.ts
+++ b/src/app/messages-page/messages-inbox/messages-inbox.component.ts
@@ -10,6 +10,7 @@ import { GlobalVarsService } from '../../global-vars.service';
 import { BackendApiService, User } from '../../backend-api.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import * as _ from 'lodash';
+import { createOfflineCompileUrlResolver } from '@angular/compiler';
 
 @Component({
   selector: 'messages-inbox',
@@ -115,10 +116,10 @@ export class MessagesInboxComponent implements OnInit, OnChanges {
 
     let fetchAfterPubKey = '';
     if (this.globalVars.messageResponse.OrderedContactsWithMessages) {
-      fetchAfterPubKey = this.globalVars.messageResponse
-        .OrderedContactsWithMessages[
-        this.globalVars.messageResponse.OrderedContactsWithMessages.length - 1
-      ].PublicKeyBase58Check;
+      fetchAfterPubKey =
+        this.globalVars.messageResponse.OrderedContactsWithMessages[
+          this.globalVars.messageResponse.OrderedContactsWithMessages.length - 1
+        ].PublicKeyBase58Check;
     }
 
     this.backendApi
@@ -131,7 +132,8 @@ export class MessagesInboxComponent implements OnInit, OnChanges {
         this.globalVars.messagesRequestsHoldingsOnly,
         this.globalVars.messagesRequestsFollowersOnly,
         this.globalVars.messagesRequestsFollowedOnly,
-        this.globalVars.messagesSortAlgorithm
+        this.globalVars.messagesSortAlgorithm,
+        this.globalVars.feeRateDeSoPerKB * 1e9
       )
       .toPromise()
       .then(
@@ -150,9 +152,10 @@ export class MessagesInboxComponent implements OnInit, OnChanges {
               JSON.stringify(res)
             ) {
               // Add the new contacts
-              this.globalVars.messageResponse.OrderedContactsWithMessages = this.globalVars.messageResponse.OrderedContactsWithMessages.concat(
-                res.OrderedContactsWithMessages
-              );
+              this.globalVars.messageResponse.OrderedContactsWithMessages =
+                this.globalVars.messageResponse.OrderedContactsWithMessages.concat(
+                  res.OrderedContactsWithMessages
+                );
 
               // If they're a new contact, add their read/unread status mapping
               for (let key in res.UnreadStateByContact) {
@@ -216,8 +219,8 @@ export class MessagesInboxComponent implements OnInit, OnChanges {
     // TODO: refactor silly setInterval
     let interval = setInterval(() => {
       // If we don't have the messageResponse yet, return
-      let orderedContactsWithMessages = this.globalVars.messageResponse
-        ?.OrderedContactsWithMessages;
+      let orderedContactsWithMessages =
+        this.globalVars.messageResponse?.OrderedContactsWithMessages;
       if (orderedContactsWithMessages == null) {
         return;
       }
@@ -339,9 +342,8 @@ export class MessagesInboxComponent implements OnInit, OnChanges {
 
     // We update the read message state on global vars before sending the request so it is more instant.
     if (this.globalVars.messageResponse.UnreadStateByContact[contactPubKey]) {
-      this.globalVars.messageResponse.UnreadStateByContact[
-        contactPubKey
-      ] = false;
+      this.globalVars.messageResponse.UnreadStateByContact[contactPubKey] =
+        false;
       this.globalVars.messageResponse.NumberOfUnreadThreads -= 1;
 
       // Send an update back to the server noting that we read this thread.


### PR DESCRIPTION
- add `encryptedMessagingKeyRandomness`, `derivedPublicKeyBase58Check` and `ownerPublicKeyBase58Check` to identity params
- set `encryptedMessagingKeyRandomness` on user after generating default key
- handle errors from identity if a derived (aka metamask) user is trying to encrypt/decrypt without `encryptedMessagingKeyRandomess`
  - sweet alert to tell user we need them to open identity to generate default key, take response from messaging group and update user in local storage, try encrypting/decrypting again if success and proceed with execution
- update types