### PR TITLE
Fix: use latest market price for calculating deso exchange rate

### DIFF
--- a/src/app/admin/admin.component.ts
+++ b/src/app/admin/admin.component.ts
@@ -512,9 +512,8 @@ export class AdminComponent implements OnInit {
   }
 
   addMultiplierToTxnTypeMultiplier() {
-    this.hotFeedTxnTypeMultiplierMap[
-      this.hotFeedTxnTypeMultiplierNewKey
-    ] = this.hotFeedTxnTypeMultiplierNewValue;
+    this.hotFeedTxnTypeMultiplierMap[this.hotFeedTxnTypeMultiplierNewKey] =
+      this.hotFeedTxnTypeMultiplierNewValue;
     this.hotFeedTxnTypeMultiplierNewKey = null;
     this.hotFeedTxnTypeMultiplierNewValue = null;
   }
@@ -841,7 +840,8 @@ export class AdminComponent implements OnInit {
       .GetUSDCentsToDeSoReserveExchangeRate(this.globalVars.localNode)
       .subscribe(
         (res) =>
-          (this.usdToDeSoReserveExchangeRate = res.USDCentsPerDeSo / 100),
+          (this.usdToDeSoReserveExchangeRate =
+            res.USDCentsPerDeSoCoinbase / 100),
         (err) => console.log(err)
       );
   }
@@ -1244,7 +1244,7 @@ export class AdminComponent implements OnInit {
               this.globalVars._alertSuccess(
                 sprintf(
                   'Successfully updated the reserve exchange to $%d/DeSo',
-                  res.USDCentsPerDeSo / 100
+                  res.USDCentsPerDeSoCoinbase / 100
                 )
               );
             },
@@ -1286,7 +1286,7 @@ export class AdminComponent implements OnInit {
               this.globalVars._alertSuccess(
                 sprintf(
                   'Successfully updated the Buy DeSo Fee to %d%',
-                  res.USDCentsPerDeSo / 100
+                  res.USDCentsPerDeSoCoinbase / 100
                 )
               );
             },
@@ -1366,7 +1366,8 @@ export class AdminComponent implements OnInit {
                 // Save the minimum network fee in case we update that value then update a different global param without
                 // updating the minimum network fee.
                 if (minimumNetworkFeeNanosPerKB >= 0) {
-                  this.globalParams.MinimumNetworkFeeNanosPerKB = minimumNetworkFeeNanosPerKB;
+                  this.globalParams.MinimumNetworkFeeNanosPerKB =
+                    minimumNetworkFeeNanosPerKB;
                 }
                 const totalFeeDeSo = res.FeeNanos / 1e9;
 

--- a/src/app/admin/admin.component.ts
+++ b/src/app/admin/admin.component.ts
@@ -840,8 +840,7 @@ export class AdminComponent implements OnInit {
       .GetUSDCentsToDeSoReserveExchangeRate(this.globalVars.localNode)
       .subscribe(
         (res) =>
-          (this.usdToDeSoReserveExchangeRate =
-            res.USDCentsPerDeSoCoinbase / 100),
+          (this.usdToDeSoReserveExchangeRate = res.USDCentsPerDeSo / 100),
         (err) => console.log(err)
       );
   }
@@ -1244,7 +1243,7 @@ export class AdminComponent implements OnInit {
               this.globalVars._alertSuccess(
                 sprintf(
                   'Successfully updated the reserve exchange to $%d/DeSo',
-                  res.USDCentsPerDeSoCoinbase / 100
+                  res.USDCentsPerDeSo / 100
                 )
               );
             },
@@ -1286,7 +1285,7 @@ export class AdminComponent implements OnInit {
               this.globalVars._alertSuccess(
                 sprintf(
                   'Successfully updated the Buy DeSo Fee to %d%',
-                  res.USDCentsPerDeSoCoinbase / 100
+                  res.USDCentsPerDeSo / 100
                 )
               );
             },

--- a/src/app/buy-deso-page/buy-deso-usd/buy-deso-usd.component.ts
+++ b/src/app/buy-deso-page/buy-deso-usd/buy-deso-usd.component.ts
@@ -52,7 +52,8 @@ export class BuyDeSoUSDComponent implements OnInit {
       this.globalVars,
       this.backendApi
     );
-    this.supportedFiatCurrencies = this.wyreService.getSupportedFiatCurrencies();
+    this.supportedFiatCurrencies =
+      this.wyreService.getSupportedFiatCurrencies();
     this.wyreService.getSupportedCountries().subscribe((res) => {
       this.supportedCountries = res;
     });
@@ -98,6 +99,7 @@ export class BuyDeSoUSDComponent implements OnInit {
   }
 
   ngOnInit() {
+    this.globalVars._updateDeSoExchangeRate();
     this._refreshQuotation();
   }
 

--- a/src/app/global-vars.service.ts
+++ b/src/app/global-vars.service.ts
@@ -1222,7 +1222,7 @@ export class GlobalVarsService {
 
         // DESO
         this.NanosSold = res.NanosSold;
-        this.ExchangeUSDCentsPerDeSo = res.USDCentsPerDeSoExchangeRate;
+        this.ExchangeUSDCentsPerDeSo = res.USDCentsPerDeSoCoinbase;
         this.USDCentsPerDeSoReservePrice =
           res.USDCentsPerDeSoReserveExchangeRate;
         this.BuyDeSoFeeBasisPoints = res.BuyDeSoFeeBasisPoints;


### PR DESCRIPTION
**What's been done**:
- Swapping all the occurrences of `ExchangeUSDCentsPerDeSo` to `USDCentsPerDeSoExchangeRate`