### PR TITLE
Nftz audio embed

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -95,6 +95,7 @@ header @html Content-Security-Policy "
     https://player.twitch.tv
     https://clips.twitch.tv
     https://mousai.stream
+    https://nftz.me
     pay.testwyre.com
     pay.sendwyre.com
     https://iframe.videodelivery.net;

--- a/src/lib/services/embed-url-parser-service/embed-url-parser-service.ts
+++ b/src/lib/services/embed-url-parser-service/embed-url-parser-service.ts
@@ -449,7 +449,7 @@ export class EmbedUrlParserService {
       return 165;
     }
     if (this.isValidNFTzEmbedURL(link)) {
-      return 525;
+      return 480;
     }
     return 315;
   }

--- a/src/lib/services/embed-url-parser-service/embed-url-parser-service.ts
+++ b/src/lib/services/embed-url-parser-service/embed-url-parser-service.ts
@@ -359,7 +359,7 @@ export class EmbedUrlParserService {
   }
 
   static isNFTzFromURL(url: URL): boolean {
-    const pattern = /\nftz\.me$/;
+    const pattern = /\bnftz\.me$/;
     return pattern.test(url.hostname);
   }
 

--- a/src/lib/services/embed-url-parser-service/embed-url-parser-service.ts
+++ b/src/lib/services/embed-url-parser-service/embed-url-parser-service.ts
@@ -232,7 +232,6 @@ export class EmbedUrlParserService {
       return of(this.constructSoundCloudEmbedURL(url));
     }
     if(this.isNFTzFromURL(url)){
-      console.log('is valid Url',url)
       return of(url.href)
     }
     if (this.isTwitchFromURL(url)) {
@@ -415,12 +414,10 @@ export class EmbedUrlParserService {
     const regExp = new RegExp(
       `https:\/\/nftz\.me\/iframe\/nft\/`
     );
-    console.log('embed link match',link)
     return !!link.match(regExp);
   }
 
   static isValidEmbedURL(link: string): boolean {
-    console.log('embed link',link)
     if (link) {
       return (
         this.isValidVimeoEmbedURL(link) ||

--- a/src/lib/services/embed-url-parser-service/embed-url-parser-service.ts
+++ b/src/lib/services/embed-url-parser-service/embed-url-parser-service.ts
@@ -232,7 +232,8 @@ export class EmbedUrlParserService {
       return of(this.constructSoundCloudEmbedURL(url));
     }
     if(this.isNFTzFromURL(url)){
-      return of(url)
+      console.log('is valid Url',url)
+      return of(url.href)
     }
     if (this.isTwitchFromURL(url)) {
       return of(this.constructTwitchEmbedURL(url)).pipe(
@@ -412,12 +413,14 @@ export class EmbedUrlParserService {
 
   static isValidNFTzEmbedURL(link: string): boolean {
     const regExp = new RegExp(
-      `https:\/\/nftz\.me\/(iframe)`
+      `https:\/\/nftz\.me\/iframe\/nft\/`
     );
+    console.log('embed link match',link)
     return !!link.match(regExp);
   }
 
   static isValidEmbedURL(link: string): boolean {
+    console.log('embed link',link)
     if (link) {
       return (
         this.isValidVimeoEmbedURL(link) ||
@@ -447,6 +450,9 @@ export class EmbedUrlParserService {
     }
     if (this.isValidMousaiEmbedURL(link)) {
       return 165;
+    }
+    if (this.isValidNFTzEmbedURL(link)) {
+      return 525;
     }
     return 315;
   }

--- a/src/lib/services/embed-url-parser-service/embed-url-parser-service.ts
+++ b/src/lib/services/embed-url-parser-service/embed-url-parser-service.ts
@@ -231,6 +231,9 @@ export class EmbedUrlParserService {
     if (this.isSoundCloudFromURL(url)) {
       return of(this.constructSoundCloudEmbedURL(url));
     }
+    if(this.isNFTzFromURL(url)){
+      return of(url)
+    }
     if (this.isTwitchFromURL(url)) {
       return of(this.constructTwitchEmbedURL(url)).pipe(
         map((embedURL) =>
@@ -355,6 +358,11 @@ export class EmbedUrlParserService {
     return pattern.test(url.hostname);
   }
 
+  static isNFTzFromURL(url: URL): boolean {
+    const pattern = /\nftz\.me$/;
+    return pattern.test(url.hostname);
+  }
+
   static isValidVimeoEmbedURL(link: string): boolean {
     const regExp = /(https:\/\/player\.vimeo\.com\/video\/(\d{0,15}))$/;
     return !!link.match(regExp);
@@ -402,6 +410,13 @@ export class EmbedUrlParserService {
     return !!link.match(regExp);
   }
 
+  static isValidNFTzEmbedURL(link: string): boolean {
+    const regExp = new RegExp(
+      `https:\/\/nftz\.me\/(iframe)`
+    );
+    return !!link.match(regExp);
+  }
+
   static isValidEmbedURL(link: string): boolean {
     if (link) {
       return (
@@ -413,7 +428,8 @@ export class EmbedUrlParserService {
         this.isValidSpotifyEmbedURL(link) ||
         this.isValidSoundCloudEmbedURL(link) ||
         this.isValidTwitchEmbedURL(link) ||
-        this.isValidTwitchEmbedURLWithParent(link)
+        this.isValidTwitchEmbedURLWithParent(link)||
+        this.isValidNFTzEmbedURL(link)
       );
     }
     return false;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,13 +26,5 @@
       "https": ["./node_modules/https-browserify"],
       "os": ["./node_modules/os-browserify"]
     }
-  },
-  "no-console": [
-    true,
-    "debug",
-    "info",
-    "time",
-    "timeEnd",
-    "trace"
-  ]
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,5 +26,13 @@
       "https": ["./node_modules/https-browserify"],
       "os": ["./node_modules/os-browserify"]
     }
-  }
+  },
+  "no-console": [
+    true,
+    "debug",
+    "info",
+    "time",
+    "timeEnd",
+    "trace"
+  ]
 }


### PR DESCRIPTION
This PR is to allow NFTz to use the EmbedVideoURL in extra data to display an iframe for Audio NFTs.  So they can be played on other nodes as well. Audio will not be auto played and is on demand after click on play.

Audio NFTs are new some examples:

https://nftz.me/nft/231bb6317d899125185511097fffd2b7106d1a325b458d9b4aad40a1f8f41ef6

https://nftz.me/nft/1588d17557a44cdbdfaf2d8cbb62df4c1336eae46f3e043309d4edecbec6d3a5

